### PR TITLE
fix: handle 'already uninstalled' plugins gracefully

### DIFF
--- a/test/integration/apply_test.go
+++ b/test/integration/apply_test.go
@@ -37,6 +37,17 @@ func (m *MockExecutor) Run(args ...string) error {
 	return nil
 }
 
+func (m *MockExecutor) RunWithOutput(args ...string) (string, error) {
+	m.Commands = append(m.Commands, args)
+
+	// Check if we should return an error
+	cmdKey := strings.Join(args[:min(3, len(args))], " ")
+	if err, ok := m.Errors[cmdKey]; ok {
+		return "", err
+	}
+	return "✔ Successfully uninstalled plugin\n", nil
+}
+
 func (m *MockExecutor) CommandCount() int {
 	return len(m.Commands)
 }


### PR DESCRIPTION
## Summary
When `claude plugin uninstall` returns exit code 1 with "already uninstalled" message, treat it as success instead of error.

This fixes the issue where `claudeup setup` reports errors for plugins that are already uninstalled (e.g., plugins with broken paths that can't be found).

## Changes
- Add `RunWithOutput` method to `CommandExecutor` interface
- Check output for "already uninstalled" and treat as success
- Update mock executor for tests

## Test plan
- [x] `go test ./...` passes
- [x] Manual test with `claudeup setup` on a system with broken plugin paths