### PR TITLE
feat: support both V1 and V2 installed_plugins.json formats

### DIFF
--- a/internal/claude/plugins_test.go
+++ b/internal/claude/plugins_test.go
@@ -62,11 +62,12 @@ func TestPluginPathExists(t *testing.T) {
 
 func TestDisablePlugin(t *testing.T) {
 	registry := &PluginRegistry{
-		Version: 1,
-		Plugins: map[string]PluginMetadata{
-			"test-plugin": {
+		Version: 2,
+		Plugins: map[string][]PluginMetadata{
+			"test-plugin": {{
+				Scope:   "user",
 				Version: "1.0.0",
-			},
+			}},
 		},
 	}
 
@@ -76,7 +77,7 @@ func TestDisablePlugin(t *testing.T) {
 	}
 
 	// Verify plugin was removed
-	if _, exists := registry.Plugins["test-plugin"]; exists {
+	if _, exists := registry.GetPlugin("test-plugin"); exists {
 		t.Error("Plugin should be removed from registry after disable")
 	}
 
@@ -88,11 +89,12 @@ func TestDisablePlugin(t *testing.T) {
 
 func TestEnablePlugin(t *testing.T) {
 	registry := &PluginRegistry{
-		Version: 1,
-		Plugins: make(map[string]PluginMetadata),
+		Version: 2,
+		Plugins: make(map[string][]PluginMetadata),
 	}
 
 	metadata := PluginMetadata{
+		Scope:       "user",
 		Version:     "1.0.0",
 		InstallPath: "/test/path",
 	}
@@ -101,7 +103,7 @@ func TestEnablePlugin(t *testing.T) {
 	registry.EnablePlugin("test-plugin", metadata)
 
 	// Verify plugin was added
-	plugin, exists := registry.Plugins["test-plugin"]
+	plugin, exists := registry.GetPlugin("test-plugin")
 	if !exists {
 		t.Error("Plugin should exist after enable")
 	}
@@ -117,11 +119,12 @@ func TestEnablePlugin(t *testing.T) {
 
 func TestPluginExists(t *testing.T) {
 	registry := &PluginRegistry{
-		Version: 1,
-		Plugins: map[string]PluginMetadata{
-			"existing-plugin": {
+		Version: 2,
+		Plugins: map[string][]PluginMetadata{
+			"existing-plugin": {{
+				Scope:   "user",
 				Version: "1.0.0",
-			},
+			}},
 		},
 	}
 
@@ -150,14 +153,15 @@ func TestLoadAndSavePlugins(t *testing.T) {
 
 	// Create test registry
 	registry := &PluginRegistry{
-		Version: 1,
-		Plugins: map[string]PluginMetadata{
-			"test-plugin@test-marketplace": {
+		Version: 2,
+		Plugins: map[string][]PluginMetadata{
+			"test-plugin@test-marketplace": {{
+				Scope:        "user",
 				Version:      "1.0.0",
 				InstallPath:  "/test/path",
 				GitCommitSha: "abc123",
 				IsLocal:      true,
-			},
+			}},
 		},
 	}
 
@@ -179,11 +183,11 @@ func TestLoadAndSavePlugins(t *testing.T) {
 	}
 
 	// Verify loaded data
-	if loaded.Version != 1 {
-		t.Errorf("Expected version 1, got %d", loaded.Version)
+	if loaded.Version != 2 {
+		t.Errorf("Expected version 2, got %d", loaded.Version)
 	}
 
-	plugin, exists := loaded.Plugins["test-plugin@test-marketplace"]
+	plugin, exists := loaded.GetPlugin("test-plugin@test-marketplace")
 	if !exists {
 		t.Error("Plugin should exist in loaded registry")
 	}
@@ -207,8 +211,8 @@ func TestLoadPluginsNonExistent(t *testing.T) {
 
 func TestSavePluginsInvalidPath(t *testing.T) {
 	registry := &PluginRegistry{
-		Version: 1,
-		Plugins: make(map[string]PluginMetadata),
+		Version: 2,
+		Plugins: make(map[string][]PluginMetadata),
 	}
 
 	// Try to save to invalid path
@@ -220,14 +224,15 @@ func TestSavePluginsInvalidPath(t *testing.T) {
 
 func TestPluginRegistryJSONMarshaling(t *testing.T) {
 	registry := &PluginRegistry{
-		Version: 1,
-		Plugins: map[string]PluginMetadata{
-			"test-plugin": {
+		Version: 2,
+		Plugins: map[string][]PluginMetadata{
+			"test-plugin": {{
+				Scope:        "user",
 				Version:      "1.0.0",
 				InstallPath:  "/test/path",
 				GitCommitSha: "abc123",
 				IsLocal:      false,
-			},
+			}},
 		},
 	}
 
@@ -252,8 +257,8 @@ func TestPluginRegistryJSONMarshaling(t *testing.T) {
 		t.Error("Plugin count mismatch after JSON round-trip")
 	}
 
-	plugin := loaded.Plugins["test-plugin"]
-	if plugin.Version != "1.0.0" {
+	plugin, exists := loaded.GetPlugin("test-plugin")
+	if !exists || plugin.Version != "1.0.0" {
 		t.Error("Plugin version mismatch after JSON round-trip")
 	}
 }

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -127,9 +127,9 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 		}
 		if confirm {
 			for _, issue := range fixableIssues {
-				if plugin, exists := plugins.Plugins[issue.PluginName]; exists {
+				if plugin, exists := plugins.GetPlugin(issue.PluginName); exists {
 					plugin.InstallPath = issue.ExpectedPath
-					plugins.Plugins[issue.PluginName] = plugin
+					plugins.SetPlugin(issue.PluginName, plugin)
 					fixed++
 				}
 			}

--- a/internal/commands/disable.go
+++ b/internal/commands/disable.go
@@ -50,7 +50,7 @@ func runDisable(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if plugin exists
-	pluginMeta, exists := plugins.Plugins[pluginName]
+	pluginMeta, exists := plugins.GetPlugin(pluginName)
 	if !exists {
 		return fmt.Errorf("plugin not found: %s", pluginName)
 	}

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -39,7 +39,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	plugins, err := claude.LoadPlugins(claudeDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			plugins = &claude.PluginRegistry{Plugins: make(map[string]claude.PluginMetadata)}
+			plugins = &claude.PluginRegistry{Plugins: make(map[string][]claude.PluginMetadata)}
 		} else {
 			return fmt.Errorf("failed to load plugins: %w", err)
 		}
@@ -138,7 +138,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 func analyzePathIssues(plugins *claude.PluginRegistry) []PathIssue {
 	var issues []PathIssue
 
-	for name, plugin := range plugins.Plugins {
+	for name, plugin := range plugins.GetAllPlugins() {
 		if !plugin.PathExists() {
 			// Check if this is a fixable path issue
 			expectedPath := getExpectedPath(name, plugin.InstallPath)

--- a/internal/commands/plugins.go
+++ b/internal/commands/plugins.go
@@ -33,9 +33,12 @@ func runPluginsList(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to load plugins: %w", err)
 	}
 
+	// Get all plugins (user-scoped)
+	allPlugins := plugins.GetAllPlugins()
+
 	// Sort plugin names for consistent output
-	names := make([]string, 0, len(plugins.Plugins))
-	for name := range plugins.Plugins {
+	names := make([]string, 0, len(allPlugins))
+	for name := range allPlugins {
 		names = append(names, name)
 	}
 	sort.Strings(names)
@@ -46,7 +49,7 @@ func runPluginsList(cmd *cobra.Command, args []string) error {
 	enabledCount := 0
 	staleCount := 0
 
-	for _, plugin := range plugins.Plugins {
+	for _, plugin := range allPlugins {
 		if plugin.IsLocal {
 			localCount++
 		} else {
@@ -79,7 +82,7 @@ func runPluginsList(cmd *cobra.Command, args []string) error {
 
 	// Print each plugin
 	for _, name := range names {
-		plugin := plugins.Plugins[name]
+		plugin := allPlugins[name]
 		status := "✓"
 		statusText := "enabled"
 

--- a/internal/commands/profile_cmd.go
+++ b/internal/commands/profile_cmd.go
@@ -239,7 +239,7 @@ func cleanupStalePlugins(claudeDir string) {
 	}
 
 	removed := 0
-	for name, plugin := range plugins.Plugins {
+	for name, plugin := range plugins.GetAllPlugins() {
 		if !plugin.PathExists() {
 			if plugins.DisablePlugin(name) {
 				removed++

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -57,7 +57,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	disabledPlugins := []string{}
 	stalePlugins := []string{}
 
-	for name, plugin := range plugins.Plugins {
+	for name, plugin := range plugins.GetAllPlugins() {
 		if plugin.PathExists() {
 			enabledCount++
 		} else {
@@ -66,7 +66,7 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Print plugins summary
-	fmt.Printf("\nPlugins (%d total)\n", len(plugins.Plugins))
+	fmt.Printf("\nPlugins (%d total)\n", len(plugins.GetAllPlugins()))
 	fmt.Printf("  ✓ %d enabled\n", enabledCount)
 	if len(disabledPlugins) > 0 {
 		fmt.Printf("  ✗ %d disabled\n", len(disabledPlugins))

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -249,7 +249,7 @@ func checkMarketplaceUpdates(marketplaces claude.MarketplaceRegistry) []Marketpl
 func checkPluginUpdates(plugins *claude.PluginRegistry, marketplaces claude.MarketplaceRegistry) []PluginUpdate {
 	var updates []PluginUpdate
 
-	for name, plugin := range plugins.Plugins {
+	for name, plugin := range plugins.GetAllPlugins() {
 		// Skip if plugin path doesn't exist
 		if !plugin.PathExists() {
 			continue
@@ -305,7 +305,7 @@ func updateMarketplace(name, path string) error {
 }
 
 func updatePlugin(name string, plugins *claude.PluginRegistry) error {
-	plugin, exists := plugins.Plugins[name]
+	plugin, exists := plugins.GetPlugin(name)
 	if !exists {
 		return fmt.Errorf("plugin not found")
 	}
@@ -368,7 +368,7 @@ func updatePlugin(name string, plugins *claude.PluginRegistry) error {
 
 	// Update the gitCommitSha
 	plugin.GitCommitSha = latestCommit
-	plugins.Plugins[name] = plugin
+	plugins.SetPlugin(name, plugin)
 
 	return nil
 }

--- a/internal/mcp/discovery.go
+++ b/internal/mcp/discovery.go
@@ -35,7 +35,7 @@ type PluginMCPServers struct {
 func DiscoverMCPServers(pluginRegistry *claude.PluginRegistry) ([]PluginMCPServers, error) {
 	var results []PluginMCPServers
 
-	for name, plugin := range pluginRegistry.Plugins {
+	for name, plugin := range pluginRegistry.GetAllPlugins() {
 		// Skip plugins with non-existent paths
 		if !plugin.PathExists() {
 			continue

--- a/internal/profile/snapshot.go
+++ b/internal/profile/snapshot.go
@@ -22,14 +22,15 @@ type ClaudeMCPServer struct {
 	Env     map[string]string `json:"env"`
 }
 
-// PluginRegistry represents installed_plugins.json
+// PluginRegistry represents installed_plugins.json (V2 format with arrays)
 type PluginRegistry struct {
-	Version int                       `json:"version"`
-	Plugins map[string]PluginMetadata `json:"plugins"`
+	Version int                         `json:"version"`
+	Plugins map[string][]PluginMetadata `json:"plugins"`
 }
 
 // PluginMetadata represents metadata for an installed plugin
 type PluginMetadata struct {
+	Scope       string `json:"scope"`
 	Version     string `json:"version"`
 	InstallPath string `json:"installPath"`
 }


### PR DESCRIPTION
## Summary

Adds backward/forward compatibility for Claude CLI's `installed_plugins.json` format changes. Fixes the breaking error when Claude CLI uses V2 format (arrays with scopes).

## Changes

- Update `PluginRegistry` to use `map[string][]PluginMetadata` (V2 format)
- Add `Scope` field to `PluginMetadata` for user/project scope support
- Add helper methods: `GetPlugin()`, `SetPlugin()`, `GetAllPlugins()`
- `LoadPlugins()` now auto-migrates V1 → V2 format transparently
- Update all command files to use helper methods instead of direct map access
- Update `profile/snapshot.go` structs for V2 compatibility
- Fix all tests to use V2 format

## Root Cause

Claude CLI evolved `installed_plugins.json` from:
- **V1**: `{"plugins": {"name": {...}}}`  (single objects)
- **V2**: `{"plugins": {"name": [{...}]}}` (arrays with scope support)

claudeup's structs only supported V1, causing unmarshal errors with V2.

## Testing

- ✅ All `internal/claude` tests pass
- ✅ Verified with both V1 and V2 format files
- ✅ Manual testing: `claudeup cleanup --dry-run` works
- ✅ Backward compatibility: V1 files auto-migrate to V2

## Fixes

```
Error: failed to load plugins: json: cannot unmarshal array into Go struct field 
PluginRegistry.plugins of type claude.PluginMetadata
```