### PR TITLE
fix: make 'current' a reserved keyword for active profile

### DIFF
--- a/internal/profile/snapshot.go
+++ b/internal/profile/snapshot.go
@@ -100,11 +100,16 @@ func readMarketplaces(claudeDir string) ([]Marketplace, error) {
 
 	var marketplaces []Marketplace
 	for _, meta := range registry {
-		marketplaces = append(marketplaces, Marketplace{
+		m := Marketplace{
 			Source: meta.Source.Source,
 			Repo:   meta.Source.Repo,
 			URL:    meta.Source.URL,
-		})
+		}
+		// Filter out invalid marketplaces (no repo or url)
+		if m.DisplayName() == "" {
+			continue
+		}
+		marketplaces = append(marketplaces, m)
 	}
 
 	// Sort by repo (or URL for git sources) for consistent output

--- a/test/acceptance/profile_current_keyword_test.go
+++ b/test/acceptance/profile_current_keyword_test.go
@@ -1,0 +1,87 @@
+// ABOUTME: Acceptance tests for 'current' keyword handling in profile commands
+// ABOUTME: Tests that 'current' is reserved and shows/refers to the active profile
+package acceptance
+
+import (
+	"github.com/claudeup/claudeup/internal/profile"
+	"github.com/claudeup/claudeup/test/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("'current' keyword handling", func() {
+	var env *helpers.TestEnv
+
+	BeforeEach(func() {
+		env = helpers.NewTestEnv(binaryPath)
+		env.CreateClaudeSettings()
+	})
+
+	Describe("profile show current", func() {
+		Context("when an active profile is set", func() {
+			BeforeEach(func() {
+				env.CreateProfile(&profile.Profile{
+					Name:        "my-active-profile",
+					Description: "This is my active profile",
+					Plugins:     []string{"plugin-a@marketplace", "plugin-b@marketplace"},
+					Marketplaces: []profile.Marketplace{
+						{Source: "github", Repo: "test/marketplace"},
+					},
+				})
+				env.SetActiveProfile("my-active-profile")
+			})
+
+			It("shows the active profile contents", func() {
+				result := env.Run("profile", "show", "current")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).To(ContainSubstring("my-active-profile"))
+				Expect(result.Stdout).To(ContainSubstring("This is my active profile"))
+				Expect(result.Stdout).To(ContainSubstring("plugin-a@marketplace"))
+				Expect(result.Stdout).To(ContainSubstring("test/marketplace"))
+			})
+		})
+
+		Context("when no active profile is set", func() {
+			It("returns an error", func() {
+				result := env.Run("profile", "show", "current")
+
+				Expect(result.ExitCode).NotTo(Equal(0))
+				Expect(result.Stderr).To(ContainSubstring("no active profile"))
+			})
+		})
+	})
+
+	Describe("profile save current", func() {
+		It("rejects 'current' as a reserved name", func() {
+			result := env.Run("profile", "save", "current")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("reserved"))
+		})
+	})
+
+	Describe("profile create current", func() {
+		BeforeEach(func() {
+			env.CreateProfile(&profile.Profile{
+				Name: "source-profile",
+			})
+		})
+
+		It("rejects 'current' as a reserved name", func() {
+			result := env.Run("profile", "create", "current", "--from", "source-profile")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("reserved"))
+		})
+	})
+
+	Describe("profile use current", func() {
+		It("rejects 'current' as a reserved name", func() {
+			result := env.Run("profile", "use", "current")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("reserved"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- `profile show current` now displays the currently active profile instead of looking for a profile literally named "current"
- `profile save current`, `profile create current`, and `profile use current` now reject "current" as a reserved name with a helpful error message  
- Snapshot now filters out invalid marketplaces (those with empty DisplayName, e.g., git source with no url)

## Breaking Change

If you have an existing profile named "current", you'll need to rename it:

```bash
# Rename the file
mv ~/.claudeup/profiles/current.json ~/.claudeup/profiles/my-setup.json

# Edit the file to update the name field
# Change: "name": "current"
# To:     "name": "my-setup"
```

## Test plan

- [x] All existing tests pass
- [x] New acceptance tests for 'current' keyword handling (5 tests)
- [x] New unit test for invalid marketplace filtering
- [ ] Manual verification: `claudeup profile show current` shows active profile
- [ ] Manual verification: `claudeup profile save current` returns reserved name error
- [ ] Manual verification: `claudeup profile create current --from default` returns reserved name error
- [ ] Manual verification: `claudeup profile use current` returns reserved name error