### PR TITLE
feat: add profile rename command

### DIFF
--- a/test/acceptance/profile_list_test.go
+++ b/test/acceptance/profile_list_test.go
@@ -147,6 +147,42 @@ var _ = Describe("profile list", func() {
 			Expect(result.Stdout).To(MatchRegexp(`\*\s+my-profile`))
 		})
 	})
+
+	Describe("reserved name warning", func() {
+		Context("when a profile named 'current' exists", func() {
+			BeforeEach(func() {
+				env.CreateProfile(&profile.Profile{
+					Name:        "current",
+					Description: "Old profile with reserved name",
+				})
+			})
+
+			It("shows a warning about the reserved name", func() {
+				result := env.Run("profile", "list")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).To(ContainSubstring("current"))
+				Expect(result.Stdout).To(ContainSubstring("reserved"))
+				Expect(result.Stdout).To(ContainSubstring("profile rename"))
+			})
+		})
+
+		Context("when no profile named 'current' exists", func() {
+			BeforeEach(func() {
+				env.CreateProfile(&profile.Profile{
+					Name:        "my-profile",
+					Description: "Normal profile",
+				})
+			})
+
+			It("does not show a warning", func() {
+				result := env.Run("profile", "list")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).NotTo(ContainSubstring("reserved"))
+			})
+		})
+	})
 })
 
 var _ = Describe("profile delete", func() {

--- a/test/acceptance/profile_rename_test.go
+++ b/test/acceptance/profile_rename_test.go
@@ -1,0 +1,117 @@
+// ABOUTME: Acceptance tests for profile rename command
+// ABOUTME: Tests CLI behavior for renaming profiles
+package acceptance
+
+import (
+	"github.com/claudeup/claudeup/internal/profile"
+	"github.com/claudeup/claudeup/test/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("profile rename", func() {
+	var env *helpers.TestEnv
+
+	BeforeEach(func() {
+		env = helpers.NewTestEnv(binaryPath)
+		env.CreateClaudeSettings()
+	})
+
+	Context("with valid arguments", func() {
+		BeforeEach(func() {
+			env.CreateProfile(&profile.Profile{
+				Name:        "old-name",
+				Description: "My profile",
+				Plugins:     []string{"plugin-a@marketplace"},
+			})
+		})
+
+		It("renames the profile file", func() {
+			result := env.Run("profile", "rename", "old-name", "new-name")
+
+			Expect(result.ExitCode).To(Equal(0))
+			Expect(result.Stdout).To(ContainSubstring("Renamed"))
+			Expect(env.ProfileExists("new-name")).To(BeTrue())
+			Expect(env.ProfileExists("old-name")).To(BeFalse())
+		})
+
+		It("updates the name field in the JSON", func() {
+			env.Run("profile", "rename", "old-name", "new-name")
+
+			renamed := env.LoadProfile("new-name")
+			Expect(renamed.Name).To(Equal("new-name"))
+			Expect(renamed.Description).To(Equal("My profile"))
+			Expect(renamed.Plugins).To(Equal([]string{"plugin-a@marketplace"}))
+		})
+	})
+
+	Context("when old-name is the active profile", func() {
+		BeforeEach(func() {
+			env.CreateProfile(&profile.Profile{Name: "active-profile"})
+			env.SetActiveProfile("active-profile")
+		})
+
+		It("updates the active profile config", func() {
+			result := env.Run("profile", "rename", "active-profile", "renamed-profile")
+
+			Expect(result.ExitCode).To(Equal(0))
+
+			// Verify active profile was updated by checking profile current
+			currentResult := env.Run("profile", "current")
+			Expect(currentResult.Stdout).To(ContainSubstring("renamed-profile"))
+		})
+	})
+
+	Context("when new-name already exists", func() {
+		BeforeEach(func() {
+			env.CreateProfile(&profile.Profile{Name: "source"})
+			env.CreateProfile(&profile.Profile{Name: "target"})
+		})
+
+		It("returns an error without -y flag", func() {
+			result := env.Run("profile", "rename", "source", "target")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("already exists"))
+		})
+
+		It("overwrites with -y flag", func() {
+			result := env.Run("profile", "rename", "source", "target", "-y")
+
+			Expect(result.ExitCode).To(Equal(0))
+			Expect(env.ProfileExists("target")).To(BeTrue())
+			Expect(env.ProfileExists("source")).To(BeFalse())
+		})
+	})
+
+	Context("when new-name is 'current'", func() {
+		BeforeEach(func() {
+			env.CreateProfile(&profile.Profile{Name: "my-profile"})
+		})
+
+		It("rejects the reserved name", func() {
+			result := env.Run("profile", "rename", "my-profile", "current")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("reserved"))
+		})
+	})
+
+	Context("when old-name doesn't exist", func() {
+		It("returns an error", func() {
+			result := env.Run("profile", "rename", "nonexistent", "new-name")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("not found"))
+		})
+	})
+
+	Context("when renaming a built-in profile", func() {
+		It("returns an error", func() {
+			result := env.Run("profile", "rename", "default", "my-default")
+
+			Expect(result.ExitCode).NotTo(Equal(0))
+			Expect(result.Stderr).To(ContainSubstring("built-in"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Adds `claudeup profile rename <old-name> <new-name>` command to rename profiles.

Closes #20

## Features

- Renames the profile file and updates the `name` field in JSON
- Updates active profile config if renamed profile was active
- Rejects reserved names like "current"
- Rejects if target name exists (unless `-y` to overwrite)
- Rejects renaming built-in profiles
- **Shows warning in `profile list` if a profile named "current" exists**

## Usage

```bash
# Basic rename
claudeup profile rename old-name new-name

# Overwrite existing profile
claudeup profile rename old-name existing-name -y

# Migrate from reserved name (for users affected by #19)
claudeup profile rename current my-setup
```

## Test plan

- [x] All existing tests pass
- [x] New acceptance tests for profile rename (8 tests)
- [x] New acceptance tests for reserved name warning (2 tests)
- [ ] Manual verification: basic rename works
- [ ] Manual verification: active profile is updated when renamed
- [ ] Manual verification: reserved name "current" is rejected as target
- [ ] Manual verification: warning shown in `profile list` when "current" exists