### PR TITLE
feat: improve help styling and add URL-based marketplace support

### DIFF
--- a/internal/claude/marketplaces.go
+++ b/internal/claude/marketplaces.go
@@ -21,7 +21,8 @@ type MarketplaceMetadata struct {
 // MarketplaceSource represents the source of a marketplace
 type MarketplaceSource struct {
 	Source string `json:"source"`
-	Repo   string `json:"repo"`
+	Repo   string `json:"repo,omitempty"`
+	URL    string `json:"url,omitempty"`
 }
 
 // LoadMarketplaces reads and parses the known_marketplaces.json file

--- a/internal/commands/marketplaces.go
+++ b/internal/commands/marketplaces.go
@@ -56,9 +56,14 @@ func runMarketplaceList(cmd *cobra.Command, args []string) error {
 
 		fmt.Printf("%s %s\n", ui.Success(ui.SymbolSuccess), ui.Bold(name))
 		fmt.Println(ui.Indent(ui.RenderDetail("Source", marketplace.Source.Source), 1))
-		fmt.Println(ui.Indent(ui.RenderDetail("Repo", marketplace.Source.Repo), 1))
-		fmt.Println(ui.Indent(ui.RenderDetail("Location", ui.Muted(marketplace.InstallLocation)), 1))
-		fmt.Println(ui.Indent(ui.RenderDetail("Updated", ui.Muted(marketplace.LastUpdated)), 1))
+		if marketplace.Source.Repo != "" {
+			fmt.Println(ui.Indent(ui.RenderDetail("Repo", marketplace.Source.Repo), 1))
+		}
+		if marketplace.Source.URL != "" {
+			fmt.Println(ui.Indent(ui.RenderDetail("URL", marketplace.Source.URL), 1))
+		}
+		fmt.Println(ui.Indent(ui.RenderDetail("Location", marketplace.InstallLocation), 1))
+		fmt.Println(ui.Indent(ui.RenderDetail("Updated", marketplace.LastUpdated), 1))
 		fmt.Println()
 	}
 

--- a/internal/commands/plugins.go
+++ b/internal/commands/plugins.go
@@ -104,8 +104,8 @@ func runPluginsList(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s %s\n", statusSymbol, ui.Bold(name))
 		fmt.Println(ui.Indent(ui.RenderDetail("Version", plugin.Version), 1))
 		fmt.Println(ui.Indent(ui.RenderDetail("Status", statusText), 1))
-		fmt.Println(ui.Indent(ui.RenderDetail("Path", ui.Muted(plugin.InstallPath)), 1))
-		fmt.Println(ui.Indent(ui.RenderDetail("Installed", ui.Muted(plugin.InstalledAt)), 1))
+		fmt.Println(ui.Indent(ui.RenderDetail("Path", plugin.InstallPath), 1))
+		fmt.Println(ui.Indent(ui.RenderDetail("Installed", plugin.InstalledAt), 1))
 
 		pluginType := "cached"
 		if plugin.IsLocal {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -16,7 +16,8 @@ var (
 	ColorWarning = lipgloss.Color("#eab308") // Yellow
 	ColorInfo    = lipgloss.Color("#06b6d4") // Cyan
 	ColorMuted   = lipgloss.Color("#6b7280") // Gray
-	ColorAccent  = lipgloss.Color("#8b5cf6") // Purple
+	ColorAccent  = lipgloss.Color("#096becff") // Blue
+	ColorFlags  = lipgloss.Color("#ffffff") // White
 )
 
 // Symbol definitions


### PR DESCRIPTION
## Summary

- Style flag usages in help output with lipgloss (flags and descriptions get consistent coloring)
- Make `[flags]` and `[command]` display consistently in usage lines (both muted)
- Fix inconsistent value styling in `plugins list` and `marketplace list` commands
- Add support for URL-based marketplaces throughout the codebase

## Test plan

- [ ] Run `claudeup marketplace --help` and verify flags section is styled
- [ ] Run `claudeup plugins list` and verify all values have consistent styling
- [ ] Run `claudeup marketplace list` and verify all values have consistent styling  
- [ ] Run `go test ./...` to verify all tests pass