### PR TITLE
fix: automatically mark saved profile as active

### DIFF
--- a/internal/commands/profile_cmd.go
+++ b/internal/commands/profile_cmd.go
@@ -524,6 +524,16 @@ func runProfileSave(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to save profile: %w", err)
 	}
 
+	// Update active profile in config
+	cfg, err := config.Load()
+	if err != nil {
+		cfg = config.DefaultConfig()
+	}
+	cfg.Preferences.ActiveProfile = name
+	if err := config.Save(cfg); err != nil {
+		ui.PrintWarning(fmt.Sprintf("Could not save active profile: %v", err))
+	}
+
 	ui.PrintSuccess(fmt.Sprintf("Saved profile %q", name))
 	fmt.Println()
 	fmt.Println(ui.Indent(ui.RenderDetail("MCP Servers", fmt.Sprintf("%d", len(p.MCPServers))), 1))

--- a/test/acceptance/profile_save_test.go
+++ b/test/acceptance/profile_save_test.go
@@ -25,6 +25,13 @@ var _ = Describe("profile save", func() {
 			Expect(result.Stdout).To(ContainSubstring("Saved profile"))
 			Expect(env.ProfileExists("my-profile")).To(BeTrue())
 		})
+
+		It("marks the saved profile as active", func() {
+			result := env.Run("profile", "save", "my-profile")
+
+			Expect(result.ExitCode).To(Equal(0))
+			Expect(env.GetActiveProfile()).To(Equal("my-profile"))
+		})
 	})
 
 	Context("with an existing profile name", func() {
@@ -55,6 +62,13 @@ var _ = Describe("profile save", func() {
 			Expect(result.ExitCode).To(Equal(0))
 			Expect(result.Stdout).To(ContainSubstring("Saved profile"))
 		})
+
+		It("marks the overwritten profile as active", func() {
+			result := env.RunWithInput("y\n", "profile", "save", "existing")
+
+			Expect(result.ExitCode).To(Equal(0))
+			Expect(env.GetActiveProfile()).To(Equal("existing"))
+		})
 	})
 
 	Context("without a profile name", func() {
@@ -70,6 +84,13 @@ var _ = Describe("profile save", func() {
 				Expect(result.ExitCode).To(Equal(0))
 				Expect(result.Stdout).To(ContainSubstring("Saving to active profile"))
 				Expect(result.Stdout).To(ContainSubstring("active-one"))
+			})
+
+			It("keeps the profile as active", func() {
+				result := env.Run("profile", "save")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(env.GetActiveProfile()).To(Equal("active-one"))
 			})
 		})
 

--- a/test/helpers/testenv.go
+++ b/test/helpers/testenv.go
@@ -126,6 +126,27 @@ func (e *TestEnv) SetActiveProfile(name string) {
 	Expect(os.WriteFile(e.ConfigFile, data, 0644)).To(Succeed())
 }
 
+// GetActiveProfile returns the active profile name from config
+func (e *TestEnv) GetActiveProfile() string {
+	data, err := os.ReadFile(e.ConfigFile)
+	if err != nil {
+		return ""
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return ""
+	}
+
+	if prefs, ok := config["preferences"].(map[string]interface{}); ok {
+		if activeProfile, ok := prefs["activeProfile"].(string); ok {
+			return activeProfile
+		}
+	}
+
+	return ""
+}
+
 // CreateClaudeSettings creates a fake claude.json settings file
 func (e *TestEnv) CreateClaudeSettings() {
 	settingsPath := filepath.Join(e.TempDir, ".claude.json")


### PR DESCRIPTION
## Summary

When you save your current settings to a profile with `claudeup profile save PROFILE_NAME`, those settings already match the profile you just saved. Therefore, that profile should be marked as active in `claudeup profile list` without needing to run a separate `claudeup profile use PROFILE_NAME` command.

This change updates `profile save` to automatically set the saved profile as the active profile in the config, matching the behavior users expect.

## Changes

- Update `runProfileSave` to mark the saved profile as active in config
- Add `GetActiveProfile` test helper method for verifying active profile
- Add comprehensive tests verifying that `profile save` marks the profile as active

## Test Plan

- ✅ All 115 existing tests pass
- ✅ Added 3 new tests covering:
  - Saving a new profile marks it as active
  - Saving over an existing profile marks it as active
  - Saving to the currently active profile keeps it active
- ✅ Manual verification shows active marker (*) appears in `profile list` after save

## Example

Before:
```bash
claudeup profile save my-profile
claudeup profile list  # my-profile not marked as active
claudeup profile use my-profile  # redundant step
```

After:
```bash
claudeup profile save my-profile
claudeup profile list  # my-profile automatically marked as active with *
```