### PR TITLE
fix: use 'profile save' instead of 'profile create' in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -176,11 +176,11 @@ if [[ -z "$EXISTING_VERSION" && -d "$HOME/.claude" ]]; then
         echo ""
         echo "Detected existing Claude Code configuration."
         echo "Creating backup profile 'my-previous-setup'..."
-        if "$INSTALL_DIR/$BINARY_NAME" profile create my-previous-setup 2>/dev/null; then
+        if "$INSTALL_DIR/$BINARY_NAME" profile save my-previous-setup --yes 2>/dev/null; then
             echo "✓ Saved current configuration as 'my-previous-setup'"
             echo "  You can restore it anytime with: $BINARY_NAME profile use my-previous-setup"
         else
-            echo "  (Could not create backup profile - you can do this manually with '$BINARY_NAME profile create')"
+            echo "  (Could not create backup profile - you can do this manually with '$BINARY_NAME profile save my-previous-setup')"
         fi
     fi
 fi


### PR DESCRIPTION
## Problem

The install.sh script was using `profile create` to backup existing Claude configurations during fresh installations. This caused several issues:

1. **Interactive prompts during install**: Users were unexpectedly prompted to select marketplaces
2. **Installation failures**: When users pressed Enter without selecting marketplaces, the backup would fail
3. **Confusing error message**: "Could not create backup profile - you can do this manually with 'claudeup profile create'"

Example of the broken UX:
```
Detected existing Claude Code configuration.
Creating backup profile 'my-previous-setup'...

Select marketplaces (enter numbers separated by commas):
  1) anthropics/claude-code
  2) obra/superpowers-marketplace
  3) malston/claude-code-templates
  4) wshobson/agents

Your selection:   (Could not create backup profile - you can do this manually with 'claudeup profile create')
```

## Solution

Changed install.sh to use `profile save my-previous-setup --yes` instead of `profile create my-previous-setup`.

The `profile save` command:
- Snapshots the current configuration non-interactively
- Uses the `--yes` flag to skip all prompts
- Works correctly with empty/fresh Claude installations
- Provides a clean, silent installation experience

## Changes

```diff
- if "$INSTALL_DIR/$BINARY_NAME" profile create my-previous-setup 2>/dev/null; then
+ if "$INSTALL_DIR/$BINARY_NAME" profile save my-previous-setup --yes 2>/dev/null; then
      echo "✓ Saved current configuration as 'my-previous-setup'"
      echo "  You can restore it anytime with: $BINARY_NAME profile use my-previous-setup"
  else
-     echo "  (Could not create backup profile - you can do this manually with '$BINARY_NAME profile create')"
+     echo "  (Could not create backup profile - you can do this manually with '$BINARY_NAME profile save my-previous-setup')"
  fi
```

## Testing

Tested with a simulated fresh install:
```bash
$ cd /tmp/test-fresh-install && bash install.sh
Downloading claudeup v1.18.4 for linux-arm64...
Installed claudeup claudeup version v1.18.4 to ~/.local/bin/claudeup

Detected existing Claude Code configuration.
Creating backup profile 'my-previous-setup'...
✓ Saved profile "my-previous-setup"

  MCP Servers: 0
  Marketplaces: 0
  Plugins: 0
✓ Saved current configuration as 'my-previous-setup'
  You can restore it anytime with: claudeup profile use my-previous-setup

Run 'claudeup setup' to get started
```

No prompts, clean install! ✓

## Impact

This fixes the installation experience in:
- Docker containers with fresh Claude installations
- CI/CD environments
- Any scenario where users run the install script with existing Claude configs

Related to the previous fix in #58 for handling fresh Claude installs.