### PR TITLE
docs: fix outdated examples and incorrect command documentation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -28,17 +28,19 @@ claudeup profile list                        # List available profiles
 claudeup profile show <name>                 # Display profile contents
 claudeup profile current                     # Show active profile (with scope)
 claudeup profile save [name]                 # Save current setup as profile
-claudeup profile create <name>               # Create profile with wizard
+claudeup profile create <name>               # Create profile with interactive wizard
+claudeup profile clone <name>                # Clone an existing profile
 claudeup profile apply <name>                # Apply a profile (user scope)
 claudeup profile suggest                     # Suggest profile for current project
 claudeup profile delete <name>               # Delete a custom profile
 claudeup profile restore <name>              # Restore a built-in profile
 claudeup profile reset <name>                # Remove everything a profile installed
 claudeup profile rename <old> <new>          # Rename a custom profile
+claudeup profile clean <plugin>              # Remove orphaned plugin from config
 
 # With description flag
 claudeup profile save my-work --description "My work setup"
-claudeup profile create home --from work --description "Home setup"
+claudeup profile clone home --from work --description "Home setup"
 ```
 
 #### Project-Level Profiles
@@ -178,8 +180,8 @@ Claude Code uses three scope levels (in precedence order):
 
 | Scope | Location | Description |
 |-------|----------|-------------|
-| `local` | `.claude/settings.local.json` | Machine-specific, highest precedence |
-| `project` | `.claude/settings.json` | Project-level, shared via git |
+| `local` | `./.claude/settings.local.json` | Machine-specific, highest precedence |
+| `project` | `./.claude/settings.json` | Project-level, shared via git |
 | `user` | `~/.claude/settings.json` | Global personal defaults |
 
 **`scope list` flags:**

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -13,7 +13,8 @@ Profiles are saved configurations of plugins, MCP servers, and marketplaces. Use
 claudeup profile list              # List available profiles
 claudeup profile show <name>       # Show profile contents
 claudeup profile save [name]       # Save current setup as a profile
-claudeup profile create <name>     # Create a profile by copying an existing one
+claudeup profile create <name>     # Create a new profile with interactive wizard
+claudeup profile clone <name>      # Clone an existing profile
 claudeup profile apply <name>        # Apply a profile
 claudeup profile reset <name>      # Remove everything a profile installed
 claudeup profile delete <name>     # Delete a custom user profile
@@ -99,7 +100,7 @@ To disable a plugin from a lower scope, explicitly set it to `false`:
 |-------|----------|---------|----------|
 | **User** | `~/.claude/settings.json` | No | Personal default plugins used everywhere |
 | **Project** | `.claude/settings.json` | Yes (via git) | Project-specific plugins, shared with team |
-| **Local** | `~/.claude/settings.local.json` | No (gitignored) | Machine-specific plugins, personal overrides |
+| **Local** | `./.claude/settings.local.json` | No (gitignored) | Machine-specific plugins, personal overrides |
 
 ### Project Scope Files
 
@@ -388,23 +389,30 @@ claudeup profile save my-work
 
 ### Creating Profiles from Existing Ones
 
-Use `profile create` to copy an existing profile with a new name:
+Use `profile clone` to copy an existing profile with a new name:
 
 ```bash
-# Interactive selection
-claudeup profile create home-setup
+# Clone from specific profile
+claudeup profile clone home-setup --from work
 
-# Copy from specific profile
-claudeup profile create home-setup --from work
+# Clone with custom description
+claudeup profile clone home-setup --from work --description "Personal development"
 
-# Copy with custom description
-claudeup profile create home-setup --from work --description "Personal development"
-
-# Copy from active profile (with -y flag)
-claudeup profile create backup -y
+# Clone from active profile (with -y flag)
+claudeup profile clone backup -y
 ```
 
-Like `profile save`, created profiles inherit the source's description (if custom) or get an auto-generated one (if the source had the old generic description).
+Like `profile save`, cloned profiles inherit the source's description (if custom) or get an auto-generated one (if the source had the old generic description).
+
+### Creating New Profiles with Wizard
+
+Use `profile create` for an interactive wizard that guides you through creating a new profile:
+
+```bash
+claudeup profile create my-new-profile
+```
+
+The wizard prompts you to select marketplaces, plugins, and configure MCP servers step by step.
 
 ## Profile Structure
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,8 +92,11 @@ claudeup events diff --file ~/.claude/plugins/installed_plugins.json --full
 **MCP server configuration issues:**
 
 ```bash
-# Check what changed in MCP configs
-claudeup events diff --file ~/.claude/mcp/mcp.json --full
+# Check what changed in user-level MCP configs
+claudeup events diff --file ~/.claude.json --full
+
+# Check what changed in project-level MCP configs
+claudeup events diff --file ./.mcp.json --full
 ```
 
 **Something changed but you don't know when:**


### PR DESCRIPTION
## Summary
- Fixes confusion between `profile create` (interactive wizard) and `profile clone` (copy existing profile)
- Adds missing documentation for `profile clone` and `profile clean` commands
- Corrects incorrect file paths in troubleshooting and scope documentation

## Changes
1. **profile create vs clone (Issue 1, 3)**: Updated description and examples to correctly distinguish the interactive wizard (`create`) from copying profiles (`clone`)
2. **profile clone docs (Issue 2)**: Added missing command to docs/commands.md
3. **profile clean docs (Issue 6)**: Added missing command to docs/commands.md  
4. **MCP file path (Issue 4)**: Fixed incorrect path `~/.claude/mcp/mcp.json` → `~/.claude.json` (user) / `./.mcp.json` (project)
5. **Local scope path (Issue 5)**: Fixed `~/.claude/settings.local.json` → `./.claude/settings.local.json` (project-relative)
6. **Scope path consistency (Issue 7)**: Added `./` prefix to project-relative paths for clarity

Fixes #77

## Test plan
- [x] Verified commands exist in codebase (`profile clone`, `profile clean`, `profile create`)
- [x] Reviewed all changes match actual command behavior