### PR TITLE
fix(examples): update scripts for current CLI syntax

### DIFF
--- a/examples/plugin-management/03-check-upgrades.sh
+++ b/examples/plugin-management/03-check-upgrades.sh
@@ -20,8 +20,8 @@ pause
 section "1. Check for Upgrades"
 
 step "See if any upgrades are available"
-run_cmd "$EXAMPLE_CLAUDEUP_BIN" upgrade --check || \
-    info "Upgrade check would show available upgrades"
+run_cmd "$EXAMPLE_CLAUDEUP_BIN" outdated || \
+    info "Outdated check would show available upgrades"
 pause
 
 section "2. Apply Upgrades"
@@ -49,7 +49,7 @@ section "Summary"
 success "You can keep plugins up to date"
 echo
 info "Key commands:"
-info "  claudeup upgrade --check  See available upgrades"
+info "  claudeup outdated         See available upgrades"
 info "  claudeup upgrade          Apply all upgrades"
 echo
 info "Tip: Run 'claudeup upgrade' regularly to get new features and fixes"

--- a/examples/profile-management/04-clone-and-modify.sh
+++ b/examples/profile-management/04-clone-and-modify.sh
@@ -31,10 +31,10 @@ info "This copies all plugins, MCP servers, and settings"
 echo
 
 if $EXAMPLE_CLAUDEUP_BIN profile list 2>/dev/null | grep -q "default"; then
-    run_cmd "$EXAMPLE_CLAUDEUP_BIN" profile clone default my-customized
+    run_cmd "$EXAMPLE_CLAUDEUP_BIN" profile clone my-customized --from default
 else
-    info "Command: claudeup profile clone <source> <new-name>"
-    info "Example: claudeup profile clone default my-customized"
+    info "Command: claudeup profile clone <new-name> --from <source>"
+    info "Example: claudeup profile clone my-customized --from default"
 fi
 pause
 
@@ -62,7 +62,7 @@ section "Summary"
 success "Clone-and-modify is a fast way to create custom profiles"
 echo
 info "Workflow:"
-info "  1. claudeup profile clone <base> <new>"
+info "  1. claudeup profile clone <new> --from <base>"
 info "  2. claudeup profile apply <new>"
 info "  3. Make your changes"
 info "  4. claudeup profile save <new>"


### PR DESCRIPTION
## Summary
- Update `03-check-upgrades.sh` to use `claudeup outdated` instead of non-existent `upgrade --check` flag
- Update `04-clone-and-modify.sh` to use current `profile clone <name> --from <source>` syntax

## Test plan
- [x] Ran all example scripts with `--non-interactive` flag
- [x] Verified both fixed scripts complete successfully