### PR TITLE
chore: update module path to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A CLI tool for managing Claude Code profiles and configurations.
 curl -fsSL https://claudeup.github.io/install.sh | bash
 
 # Or from source
-go install github.com/claudeup/claudeup/v3/cmd/claudeup@latest
+go install github.com/claudeup/claudeup/v4/cmd/claudeup@latest
 ```
 
 ## Get Started

--- a/cmd/claudeup/main.go
+++ b/cmd/claudeup/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime/debug"
 
-	"github.com/claudeup/claudeup/v3/internal/commands"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/commands"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 )
 
 var version = "dev" // Injected at build time via -ldflags

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/claudeup/claudeup/v3
+module github.com/claudeup/claudeup/v4
 
 go 1.25.1
 

--- a/internal/claude/errors.go
+++ b/internal/claude/errors.go
@@ -21,7 +21,7 @@ func (e *FormatVersionError) Error() string {
 This likely means your Claude CLI has been updated to a newer format.
 Please update claudeup:
 
-  go install github.com/claudeup/claudeup/v3@latest
+  go install github.com/claudeup/claudeup/v4@latest
 
 If the issue persists, please report at:
   https://github.com/claudeup/claudeup/issues`,

--- a/internal/claude/plugin_analysis_test.go
+++ b/internal/claude/plugin_analysis_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/internal/claude/plugins.go
+++ b/internal/claude/plugins.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 // PluginRegistry represents the installed_plugins.json file structure

--- a/internal/claude/settings.go
+++ b/internal/claude/settings.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 // canonicalKeyOrder defines the key order that Claude Code uses in settings.json.

--- a/internal/commands/cleanup.go
+++ b/internal/commands/cleanup.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -9,8 +9,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/events.go
+++ b/internal/commands/events.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/events"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/events_audit.go
+++ b/internal/commands/events_audit.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/events"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/events_diff.go
+++ b/internal/commands/events_diff.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/events"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/marketplaces.go
+++ b/internal/commands/marketplaces.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/mcp.go
+++ b/internal/commands/mcp.go
@@ -7,10 +7,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/mcp"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/mcp"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/outdated.go
+++ b/internal/commands/outdated.go
@@ -5,9 +5,9 @@ package commands
 import (
 	"fmt"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/selfupdate"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/selfupdate"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/plugin.go
+++ b/internal/commands/plugin.go
@@ -11,10 +11,10 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/plugin_search.go
+++ b/internal/commands/plugin_search.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/pluginsearch"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/pluginsearch"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/plugin_stats.go
+++ b/internal/commands/plugin_stats.go
@@ -7,8 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 )
 
 // PluginStatistics holds aggregated counts for plugin analysis

--- a/internal/commands/plugin_stats_test.go
+++ b/internal/commands/plugin_stats_test.go
@@ -5,7 +5,7 @@ package commands
 import (
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 func TestCalculatePluginStatistics(t *testing.T) {

--- a/internal/commands/profile_cmd.go
+++ b/internal/commands/profile_cmd.go
@@ -11,11 +11,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/backup"
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/backup"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/profile_cmd_test.go
+++ b/internal/commands/profile_cmd_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 )
 
 func TestLoadProfileWithFallback_LoadsFromDiskFirst(t *testing.T) {

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -3,8 +3,8 @@
 package commands
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/scope.go
+++ b/internal/commands/scope.go
@@ -7,10 +7,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/claudeup/claudeup/v3/internal/backup"
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/backup"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/scope_helpers.go
+++ b/internal/commands/scope_helpers.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"sort"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 )
 
 // ActiveProfileInfo represents an active profile at a specific scope

--- a/internal/commands/setup.go
+++ b/internal/commands/setup.go
@@ -11,10 +11,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/internal/secrets"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/secrets"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/status.go
+++ b/internal/commands/status.go
@@ -8,10 +8,10 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/update.go
+++ b/internal/commands/update.go
@@ -5,8 +5,8 @@ package commands
 import (
 	"fmt"
 
-	"github.com/claudeup/claudeup/v3/internal/selfupdate"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/selfupdate"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/commands/upgrade.go
+++ b/internal/commands/upgrade.go
@@ -11,8 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 	"github.com/spf13/cobra"
 )
 

--- a/internal/events/diff.go
+++ b/internal/events/diff.go
@@ -9,7 +9,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 )
 
 // Diff symbols for change visualization

--- a/internal/events/diff_test.go
+++ b/internal/events/diff_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 var _ = Describe("DiffSnapshots", func() {

--- a/internal/events/global.go
+++ b/internal/events/global.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/config"
 )
 
 var (

--- a/internal/events/tracker_test.go
+++ b/internal/events/tracker_test.go
@@ -14,7 +14,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 func TestEvents(t *testing.T) {

--- a/internal/events/writer_test.go
+++ b/internal/events/writer_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 var _ = Describe("JSONLWriter", func() {

--- a/internal/mcp/discovery.go
+++ b/internal/mcp/discovery.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 // ServerDefinition represents an MCP server configuration

--- a/internal/mcp/discovery_test.go
+++ b/internal/mcp/discovery_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 func TestDiscoverEnabledMCPServers(t *testing.T) {

--- a/internal/pluginsearch/formatter.go
+++ b/internal/pluginsearch/formatter.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 )
 
 // FormatOptions configures output rendering.

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/config"
-	"github.com/claudeup/claudeup/v3/internal/secrets"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/secrets"
 )
 
 // ApplyOptions controls how a profile is applied

--- a/internal/profile/apply_allscopes_test.go
+++ b/internal/profile/apply_allscopes_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 func TestApplyAllScopesMultiScope(t *testing.T) {

--- a/internal/profile/apply_concurrent.go
+++ b/internal/profile/apply_concurrent.go
@@ -7,8 +7,8 @@ import (
 	"io"
 	"os"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/ui"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/ui"
 )
 
 // ConcurrentApplyOptions configures concurrent apply behavior

--- a/internal/profile/mcp_json.go
+++ b/internal/profile/mcp_json.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 // MCPConfigFile is the filename for Claude's native MCP configuration

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -10,7 +10,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
+	"github.com/claudeup/claudeup/v4/internal/events"
 )
 
 // Profile represents a Claude Code configuration profile

--- a/internal/profile/snapshot.go
+++ b/internal/profile/snapshot.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 // ClaudeJSON represents the ~/.claude.json file structure (relevant parts)

--- a/internal/ui/prompt.go
+++ b/internal/ui/prompt.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/config"
 )
 
 // ConfirmYesNo prompts for Y/n confirmation

--- a/internal/ui/prompt_test_helpers.go
+++ b/internal/ui/prompt_test_helpers.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/config"
 )
 
 // testYesFlagMutex ensures only one test modifies YesFlag at a time

--- a/test/acceptance/acceptance_suite_test.go
+++ b/test/acceptance/acceptance_suite_test.go
@@ -19,7 +19,7 @@ func TestAcceptance(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	var err error
-	binaryPath, err = gexec.Build("github.com/claudeup/claudeup/v3/cmd/claudeup")
+	binaryPath, err = gexec.Build("github.com/claudeup/claudeup/v4/cmd/claudeup")
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/test/acceptance/events_audit_test.go
+++ b/test/acceptance/events_audit_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/events"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/events_diff_test.go
+++ b/test/acceptance/events_diff_test.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/claudeup/claudeup/v3/internal/events"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/events"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/helpers.go
+++ b/test/acceptance/helpers.go
@@ -9,8 +9,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/mcp"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/mcp"
 )
 
 // AcceptanceTestEnv represents a complete test environment with real directories

--- a/test/acceptance/mcp_list_test.go
+++ b/test/acceptance/mcp_list_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/outdated_test.go
+++ b/test/acceptance/outdated_test.go
@@ -3,7 +3,7 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/plugin_browse_test.go
+++ b/test/acceptance/plugin_browse_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/plugin_enable_disable_test.go
+++ b/test/acceptance/plugin_enable_disable_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/plugin_search_test.go
+++ b/test/acceptance/plugin_search_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/plugin_show_test.go
+++ b/test/acceptance/plugin_show_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/plugins_test.go
+++ b/test/acceptance/plugins_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_apply_hobson_test.go
+++ b/test/acceptance/profile_apply_hobson_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_apply_reset_test.go
+++ b/test/acceptance/profile_apply_reset_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 )
 
 var _ = Describe("claudeup profile apply --replace", func() {

--- a/test/acceptance/profile_clean_test.go
+++ b/test/acceptance/profile_clean_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 )
 
 var _ = Describe("Profile clean command for config drift", func() {

--- a/test/acceptance/profile_clone_test.go
+++ b/test/acceptance/profile_clone_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_concurrent_apply_test.go
+++ b/test/acceptance/profile_concurrent_apply_test.go
@@ -5,8 +5,8 @@ package acceptance
 import (
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_create_noninteractive_test.go
+++ b/test/acceptance/profile_create_noninteractive_test.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_create_test.go
+++ b/test/acceptance/profile_create_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_create_wizard_test.go
+++ b/test/acceptance/profile_create_wizard_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_current_keyword_test.go
+++ b/test/acceptance/profile_current_keyword_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_diff_builtin_test.go
+++ b/test/acceptance/profile_diff_builtin_test.go
@@ -6,8 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 )
 
 var _ = Describe("Profile diff builtin comparison", func() {

--- a/test/acceptance/profile_list_test.go
+++ b/test/acceptance/profile_list_test.go
@@ -5,8 +5,8 @@ package acceptance
 import (
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_multiscope_test.go
+++ b/test/acceptance/profile_multiscope_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_rename_test.go
+++ b/test/acceptance/profile_rename_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_reset_test.go
+++ b/test/acceptance/profile_reset_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_save_test.go
+++ b/test/acceptance/profile_save_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_scope_test.go
+++ b/test/acceptance/profile_scope_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/profile_test.go
+++ b/test/acceptance/profile_test.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/mcp"
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/mcp"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 )
 
 func TestProfileSaveAndLoad(t *testing.T) {

--- a/test/acceptance/project_profile_sharing_test.go
+++ b/test/acceptance/project_profile_sharing_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 )
 
 // Section 1: Directory structure and resolution order

--- a/test/acceptance/scope_aliases_test.go
+++ b/test/acceptance/scope_aliases_test.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/scope_clear_test.go
+++ b/test/acceptance/scope_clear_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 )
 
 var _ = Describe("claudeup scope clear", func() {

--- a/test/acceptance/scope_list_test.go
+++ b/test/acceptance/scope_list_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 )
 
 var _ = Describe("claudeup scope list", func() {

--- a/test/acceptance/scope_restore_test.go
+++ b/test/acceptance/scope_restore_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 )
 
 var _ = Describe("claudeup scope restore", func() {

--- a/test/acceptance/setup_test.go
+++ b/test/acceptance/setup_test.go
@@ -7,7 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/status_test.go
+++ b/test/acceptance/status_test.go
@@ -3,8 +3,8 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/update_test.go
+++ b/test/acceptance/update_test.go
@@ -3,7 +3,7 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/acceptance/upgrade_test.go
+++ b/test/acceptance/upgrade_test.go
@@ -3,7 +3,7 @@
 package acceptance
 
 import (
-	"github.com/claudeup/claudeup/v3/test/helpers"
+	"github.com/claudeup/claudeup/v4/test/helpers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/helpers/testenv.go
+++ b/test/helpers/testenv.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/integration/apply_test.go
+++ b/test/integration/apply_test.go
@@ -12,9 +12,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/profile"
-	"github.com/claudeup/claudeup/v3/internal/secrets"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/secrets"
 )
 
 // MockExecutor records commands for verification

--- a/test/integration/claude/format_compatibility_test.go
+++ b/test/integration/claude/format_compatibility_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 var _ = Describe("Claude CLI Format Compatibility", func() {

--- a/test/integration/enable_disable_test.go
+++ b/test/integration/enable_disable_test.go
@@ -6,7 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/config"
+	"github.com/claudeup/claudeup/v4/internal/config"
 )
 
 var _ = Describe("MCPServerDisableEnable", func() {

--- a/test/integration/helpers.go
+++ b/test/integration/helpers.go
@@ -9,8 +9,8 @@ import (
 
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/mcp"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/mcp"
 )
 
 // TestEnv represents a test environment with a fake Claude installation

--- a/test/integration/maintenance_test.go
+++ b/test/integration/maintenance_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 var _ = Describe("DoctorDetectsStalePlugins", func() {

--- a/test/integration/profile/categories_test.go
+++ b/test/integration/profile/categories_test.go
@@ -3,7 +3,7 @@
 package profile_test
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/integration/profile/settings_preservation_test.go
+++ b/test/integration/profile/settings_preservation_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/claude"
 )
 
 var _ = Describe("Profile operations preserve non-plugin settings", func() {

--- a/test/integration/profile/wizard_test.go
+++ b/test/integration/profile/wizard_test.go
@@ -3,7 +3,7 @@
 package profile_test
 
 import (
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )

--- a/test/integration/project_scope_test.go
+++ b/test/integration/project_scope_test.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 )
 
 func TestWriteMCPJSON_CreatesValidFile(t *testing.T) {

--- a/test/integration/snapshot_test.go
+++ b/test/integration/snapshot_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/profile"
+	"github.com/claudeup/claudeup/v4/internal/profile"
 )
 
 // Test environment helpers

--- a/test/integration/status_test.go
+++ b/test/integration/status_test.go
@@ -8,8 +8,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"github.com/claudeup/claudeup/v3/internal/claude"
-	"github.com/claudeup/claudeup/v3/internal/mcp"
+	"github.com/claudeup/claudeup/v4/internal/claude"
+	"github.com/claudeup/claudeup/v4/internal/mcp"
 )
 
 var _ = Describe("StatusCommand", func() {


### PR DESCRIPTION
## Summary

- Updates module path from `github.com/claudeup/claudeup/v3` to `github.com/claudeup/claudeup/v4`

## Why

Go modules require major versions >= 2 to include the version in the module path. Without this, `go install` and `go get` commands fail for v4.x releases.

## After this change

Users can install via:
```bash
go install github.com/claudeup/claudeup/v4/cmd/claudeup@latest
```

## Test plan

- [x] All internal tests pass
- [x] All acceptance tests pass (397 tests)
- [x] Build succeeds