### PR TITLE
feat: add recursive canonical key ordering for nested settings objects

### DIFF
--- a/internal/claude/settings.go
+++ b/internal/claude/settings.go
@@ -246,7 +246,7 @@ func getNestedKeyOrder(parentKey string) []string {
 	if order, ok := nestedKeyOrders[parentKey]; ok {
 		return order
 	}
-	// For unknown nested objects, return empty slice (will use alphabetical)
+	// For unknown nested objects, return nil (caller will fall back to alphabetical order)
 	return nil
 }
 

--- a/internal/claude/settings_test.go
+++ b/internal/claude/settings_test.go
@@ -823,28 +823,50 @@ func TestNestedCanonicalKeyOrder(t *testing.T) {
 	// Schema order: matcher, hooks
 	// Find the first hookMatcher (contains both "matcher" and nested "hooks")
 	matcherIdx := indexOf(content, `"matcher"`)
-	hooksArrayIdx := indexOf(content[matcherIdx:], `"hooks"`) + matcherIdx
-
 	if matcherIdx == -1 {
 		t.Error("hookMatcher.matcher not found")
 	}
-	if hooksArrayIdx <= matcherIdx {
+
+	hooksArrayIdx := -1
+	if matcherIdx != -1 {
+		if relIdx := indexOf(content[matcherIdx:], `"hooks"`); relIdx != -1 {
+			hooksArrayIdx = matcherIdx + relIdx
+		}
+	}
+	if hooksArrayIdx == -1 {
+		t.Error("hookMatcher.hooks not found")
+	} else if hooksArrayIdx <= matcherIdx {
 		t.Error("hookMatcher: 'hooks' should appear after 'matcher'")
 	}
 
 	// === Test hookCommand key order ===
 	// Schema order: type, command, timeout
 	typeIdx := indexOf(content, `"type"`)
-	commandIdx := indexOf(content[typeIdx:], `"command"`) + typeIdx
-	timeoutIdx := indexOf(content[commandIdx:], `"timeout"`) + commandIdx
-
 	if typeIdx == -1 {
 		t.Error("hookCommand.type not found")
 	}
-	if commandIdx <= typeIdx {
+
+	commandIdx := -1
+	if typeIdx != -1 {
+		if relIdx := indexOf(content[typeIdx:], `"command"`); relIdx != -1 {
+			commandIdx = typeIdx + relIdx
+		}
+	}
+	if commandIdx == -1 {
+		t.Error("hookCommand.command not found")
+	} else if commandIdx <= typeIdx {
 		t.Error("hookCommand: 'command' should appear after 'type'")
 	}
-	if timeoutIdx <= commandIdx {
+
+	timeoutIdx := -1
+	if commandIdx != -1 {
+		if relIdx := indexOf(content[commandIdx:], `"timeout"`); relIdx != -1 {
+			timeoutIdx = commandIdx + relIdx
+		}
+	}
+	if timeoutIdx == -1 {
+		t.Error("hookCommand.timeout not found")
+	} else if timeoutIdx <= commandIdx {
 		t.Error("hookCommand: 'timeout' should appear after 'command'")
 	}
 }


### PR DESCRIPTION
## Summary

- Expands `canonicalKeyOrder` from 6 to all 41 schema-defined top-level keys based on the official schema at https://www.schemastore.org/claude-code-settings.json
- Adds `nestedKeyOrders` map for canonical ordering of nested objects: `permissions`, `hooks`, `hookMatcher`, `hookCommand`, `sandbox`, and `attribution`
- Refactors `marshalCanonical` to recursively apply canonical ordering to nested objects and arrays

## Test plan

- [x] Existing `TestSaveSettingsCanonicalKeyOrder` passes
- [x] Existing `TestSaveSettingsForScopeCanonicalKeyOrder` passes
- [x] New `TestNestedCanonicalKeyOrder` verifies nested key ordering for permissions, hooks, hookMatcher, and hookCommand
- [x] All existing tests pass (`go test ./...`)