### PR TITLE
fix: filter .gitkeep files from import candidates

### DIFF
--- a/internal/local/symlinks.go
+++ b/internal/local/symlinks.go
@@ -450,7 +450,14 @@ func (m *Manager) findImportCandidates(activeDir string) ([]string, error) {
 	}
 
 	for _, entry := range entries {
-		path := filepath.Join(activeDir, entry.Name())
+		name := entry.Name()
+
+		// Skip hidden files (like .gitkeep) and CLAUDE.md
+		if strings.HasPrefix(name, ".") || name == "CLAUDE.md" {
+			continue
+		}
+
+		path := filepath.Join(activeDir, name)
 		info, err := os.Lstat(path)
 		if err != nil {
 			continue
@@ -461,7 +468,7 @@ func (m *Manager) findImportCandidates(activeDir string) ([]string, error) {
 			continue
 		}
 
-		candidates = append(candidates, entry.Name())
+		candidates = append(candidates, name)
 	}
 
 	return candidates, nil


### PR DESCRIPTION
## Summary
- Filter hidden files (like `.gitkeep`) from import candidates to prevent them from being added to `enabled.json`
- Add test coverage for `.gitkeep` filtering behavior

## Test plan
- [x] Added `TestImportSkipsGitkeep` to verify `.gitkeep` files are never imported or added to config
- [x] All existing tests pass