### PR TITLE
feat: extend local management demo with install command examples

### DIFF
--- a/scripts/demo-local-management.sh
+++ b/scripts/demo-local-management.sh
@@ -314,14 +314,14 @@ print_header "Demo Complete!"
 
 CUSTOM_AGENTS=0
 if [ -d "$CLAUDE_CONFIG_DIR/.library/agents" ]; then
-    CUSTOM_AGENTS=$(find "$CLAUDE_CONFIG_DIR/.library/agents" -maxdepth 1 \( -name 'demo-agent*' -o -name 'my-agents' \) | wc -l | tr -d ' ')
+    CUSTOM_AGENTS=$(find "$CLAUDE_CONFIG_DIR/.library/agents" -name '*.md' \( -name 'demo-agent*' -o -path '*/my-agents/*' \) | wc -l | tr -d ' ')
 fi
 
 echo "Summary:"
 echo "  - GSD agents enabled: $GSD_AGENTS"
 echo "  - GSD commands enabled: $GSD_COMMANDS files"
 echo "  - GSD hooks enabled: $GSD_HOOKS"
-echo "  - Custom agents installed: $CUSTOM_AGENTS (demo-agent + my-agents group)"
+echo "  - Custom agents installed: $CUSTOM_AGENTS (demo-agent + 2 in my-agents group)"
 echo "  - Profile saved: gsd-demo"
 echo
 echo "Commands demonstrated:"


### PR DESCRIPTION
## Summary

Extends the `demo-local-management.sh` script to demonstrate the `claudeup local install` command alongside the existing import examples.

## Changes

### New Demo Steps

**Step 9: Install External Agent (Single File)**
- Creates a custom agent file in an external directory
- Uses `claudeup local install agents demo-agent.md`
- Verifies that source file remains (install copies, not moves)

**Step 10: Install Agent Group (Directory)**
- Creates an agent group with multiple agents
- Uses `claudeup local install agents my-agents/`
- Shows how install handles directory structures

**Step 11: Final State**
- Shows all enabled items with `claudeup local list --enabled`
- Displays final `enabled.json` configuration

### Enhanced Summary

The demo summary now includes:
- Count of custom agents installed
- Commands demonstrated with checkmarks
- Clear comparison table showing key differences:
  - `import`: MOVES files (from active dirs), removes source
  - `install`: COPIES files (from anywhere), keeps source

## Motivation

The original demo only showed `import-all` (rescuing GSD installations from active directories). This PR adds demonstrations of the `install` command to show the complete local management feature set.

## Testing

Manually tested the enhanced demo script:
```bash
./scripts/demo-local-management.sh
```

All steps execute successfully and clearly demonstrate both workflows.

## Related

- Feature PR: #120 (Local item management)
- Demo script was added in #120 but only covered import workflow