### PR TITLE
fix(doctor): use dynamic scope in profile apply recommendation

### DIFF
--- a/internal/commands/doctor.go
+++ b/internal/commands/doctor.go
@@ -51,8 +51,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get current directory: %w", err)
 	}
 
-	// Get active profile for recommendations
-	activeProfile, _ := getActiveProfile(projectDir)
+	// Get active profile and scope for recommendations
+	activeProfile, activeScope := getActiveProfile(projectDir)
 
 	// Load plugins (gracefully handle fresh installs with no plugins)
 	plugins, err := claude.LoadPlugins(claudeDir)
@@ -180,12 +180,9 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 		fmt.Println(ui.Indent(ui.Bold("Recommendations:"), 1))
 
-		// Get active profile for better recommendations
-		activeProfile, _ := getActiveProfile(projectDir)
-
 		if len(missingPlugins) > 0 {
 			if activeProfile != "" && activeProfile != "none" {
-				fmt.Println(ui.Indent(ui.Info(ui.SymbolArrow+fmt.Sprintf(" Reinstall missing plugins from profile: %s", ui.Bold("claudeup profile apply"))), 1))
+				fmt.Println(ui.Indent(ui.Info(ui.SymbolArrow+fmt.Sprintf(" Reinstall missing plugins from profile: %s", ui.Bold(fmt.Sprintf("claudeup profile apply %s --scope %s", activeProfile, activeScope)))), 1))
 				fmt.Println(ui.Indent(ui.Info(ui.SymbolArrow+" Or remove from settings: "+ui.Bold("claudeup profile clean <plugin-name>")), 1))
 			} else {
 				fmt.Println(ui.Indent(ui.Info(ui.SymbolArrow+" Install missing plugins: "+ui.Bold("claude plugin install <name>")), 1))

--- a/test/acceptance/doctor_test.go
+++ b/test/acceptance/doctor_test.go
@@ -1,0 +1,64 @@
+// ABOUTME: Acceptance tests for doctor command
+// ABOUTME: Tests diagnostic output including scope-aware recommendations
+package acceptance
+
+import (
+	"github.com/claudeup/claudeup/v4/internal/profile"
+	"github.com/claudeup/claudeup/v4/test/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("doctor", func() {
+	var env *helpers.TestEnv
+
+	BeforeEach(func() {
+		env = helpers.NewTestEnv(binaryPath)
+	})
+
+	Describe("missing plugin recommendations", func() {
+		BeforeEach(func() {
+			// Create empty plugin registry first (this also creates settings)
+			env.CreateInstalledPlugins(map[string]interface{}{})
+			// Then enable a plugin in settings that is NOT installed
+			env.CreateSettings(map[string]bool{
+				"missing-plugin@test-marketplace": true,
+			})
+
+			// Create a profile that lists this plugin
+			env.CreateProfile(&profile.Profile{
+				Name:    "my-profile",
+				Plugins: []string{"missing-plugin@test-marketplace"},
+			})
+		})
+
+		Context("with user-scope active profile", func() {
+			BeforeEach(func() {
+				env.SetActiveProfile("my-profile")
+			})
+
+			It("includes profile name and --scope user in recommendation", func() {
+				result := env.Run("doctor")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).To(ContainSubstring("claudeup profile apply my-profile --scope user"))
+			})
+		})
+
+		Context("with local-scope active profile", func() {
+			var projectDir string
+
+			BeforeEach(func() {
+				projectDir = env.ProjectDir("test-project")
+				env.RegisterProject(projectDir, "my-profile")
+			})
+
+			It("includes profile name and --scope local in recommendation", func() {
+				result := env.RunInDir(projectDir, "doctor")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).To(ContainSubstring("claudeup profile apply my-profile --scope local"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Doctor now includes the active profile name and `--scope` flag in its reinstall recommendation
- Removes redundant second call to `getActiveProfile`
- Before: `claudeup profile apply`
- After: `claudeup profile apply my-profile --scope user`

## Test plan
- [x] Acceptance test for user-scope active profile recommendation
- [x] Acceptance test for local-scope active profile recommendation
- [x] Full test suite passes (431 acceptance specs + all unit/integration)

Closes #113