### PR TITLE
fix(local list): replace * and x markers with clearer indicators

### DIFF
--- a/internal/commands/local.go
+++ b/internal/commands/local.go
@@ -240,9 +240,9 @@ func runLocalList(cmd *cobra.Command, args []string) error {
 			printGroupedAgents(filtered)
 		} else {
 			for _, item := range filtered {
-				status := ui.Error("x")
+				status := ui.Muted("·")
 				if item.enabled {
-					status = ui.Success("*")
+					status = ui.Success(ui.SymbolSuccess)
 				}
 				fmt.Printf("  %s %s\n", status, item.name)
 			}
@@ -276,9 +276,9 @@ func printGroupedAgents(items []itemStatus) {
 
 	// Print flat items first
 	for _, item := range flatItems {
-		status := ui.Error("x")
+		status := ui.Muted("·")
 		if item.enabled {
-			status = ui.Success("*")
+			status = ui.Success(ui.SymbolSuccess)
 		}
 		fmt.Printf("  %s %s\n", status, item.name)
 	}
@@ -293,9 +293,9 @@ func printGroupedAgents(items []itemStatus) {
 	for _, group := range groupNames {
 		fmt.Printf("  %s/\n", group)
 		for _, item := range groups[group] {
-			status := ui.Error("x")
+			status := ui.Muted("·")
 			if item.enabled {
-				status = ui.Success("*")
+				status = ui.Success(ui.SymbolSuccess)
 			}
 			fmt.Printf("    %s %s\n", status, strings.TrimSuffix(item.name, ".md"))
 		}


### PR DESCRIPTION
## Summary
- Enabled items: `✓` (green) instead of `*`
- Disabled items: `·` (muted) instead of `x`
- Resolves conflict with `profile list` where `*` means highest-precedence active profile
- Consistent with the rest of the codebase which uses `✓`/`✗` symbols

## Test plan
- [x] Acceptance test verifying `✓` appears for enabled items
- [x] Acceptance test verifying `·` appears for disabled items
- [x] Acceptance test verifying old `*`/`x` markers are gone
- [x] Full test suite passes (438 acceptance specs + all unit/integration)

Closes #133