### PR TITLE
docs: clarify import vs install vs import-all in local help

### DIFF
--- a/internal/commands/local.go
+++ b/internal/commands/local.go
@@ -31,7 +31,12 @@ var localCmd = &cobra.Command{
 	Long: `Manage local Claude Code extensions from ~/.claudeup/local.
 
 These are local files (not marketplace plugins) that extend Claude Code
-with custom agents, commands, skills, hooks, rules, and output-styles.`,
+with custom agents, commands, skills, hooks, rules, and output-styles.
+
+Adding items to local storage:
+  install     Copy items from external paths (git repos, downloads)
+  import      Move items from active directories to local storage
+  import-all  Bulk import across all categories at once`,
 }
 
 var localListCmd = &cobra.Command{

--- a/test/acceptance/local_help_test.go
+++ b/test/acceptance/local_help_test.go
@@ -1,0 +1,40 @@
+// ABOUTME: Acceptance tests for local command help text
+// ABOUTME: Verifies help output clarifies import vs install vs import-all
+package acceptance
+
+import (
+	"github.com/claudeup/claudeup/v4/test/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("local help", func() {
+	var env *helpers.TestEnv
+
+	BeforeEach(func() {
+		env = helpers.NewTestEnv(binaryPath)
+	})
+
+	It("includes a section explaining how to add items", func() {
+		result := env.Run("local", "--help")
+
+		Expect(result.ExitCode).To(Equal(0))
+		Expect(result.Stdout).To(ContainSubstring("Adding items"))
+	})
+
+	It("explains that install copies from external paths", func() {
+		result := env.Run("local", "--help")
+
+		Expect(result.ExitCode).To(Equal(0))
+		// The description should explain install copies from external sources
+		Expect(result.Stdout).To(MatchRegexp(`(?i)install.*cop(y|ies).*external`))
+	})
+
+	It("explains that import moves from active directories", func() {
+		result := env.Run("local", "--help")
+
+		Expect(result.ExitCode).To(Equal(0))
+		// The description should explain import moves from active dirs
+		Expect(result.Stdout).To(MatchRegexp(`(?i)import\s.*mov(e|es).*active`))
+	})
+})


### PR DESCRIPTION
## Summary
- Adds an "Adding items to local storage" section to `claudeup local --help` explaining the three ingestion commands
- `install` copies from external paths (git repos, downloads)
- `import` moves from active directories to local storage
- `import-all` is bulk import across all categories

## Test plan
- [x] New acceptance tests verify the help text contains the guidance section
- [x] Full test suite passes (441 acceptance specs + all unit/integration tests)

Closes #135