### PR TITLE
feat(local list): add per-category item counts in full listing

### DIFF
--- a/internal/commands/local.go
+++ b/internal/commands/local.go
@@ -305,6 +305,15 @@ func runLocalList(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
+
+		// Per-category count line
+		enabledCount := 0
+		for _, item := range items {
+			if catConfig[item] {
+				enabledCount++
+			}
+		}
+		fmt.Printf("  %d items (%d enabled)\n", len(items), enabledCount)
 	}
 
 	if totalItems == 0 && len(args) == 0 {

--- a/test/acceptance/local_list_test.go
+++ b/test/acceptance/local_list_test.go
@@ -168,6 +168,30 @@ var _ = Describe("local list", func() {
 			})
 		})
 
+		Context("per-category counts", func() {
+			It("shows count after items in specific category listing", func() {
+				result := env.Run("local", "list", "rules")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).To(MatchRegexp(`2 items \(1 enabled\)`))
+			})
+
+			It("shows count after items with --full flag", func() {
+				result := env.Run("local", "list", "--full")
+
+				Expect(result.ExitCode).To(Equal(0))
+				Expect(result.Stdout).To(MatchRegexp(`2 items \(1 enabled\)`))
+			})
+
+			It("does not show count in summary mode", func() {
+				result := env.Run("local", "list")
+
+				Expect(result.ExitCode).To(Equal(0))
+				// Summary mode already shows counts inline, no duplicate
+				Expect(result.Stdout).NotTo(MatchRegexp(`\n\s+2 items \(1 enabled\)\n`))
+			})
+		})
+
 		Context("full listing", func() {
 			It("shows individual items with --full flag", func() {
 				result := env.Run("local", "list", "--full")


### PR DESCRIPTION
## Summary
- Adds per-category count line after items in full listing mode (e.g., `4 items (2 enabled)`)
- Shows total item count and enabled count for each category
- Does not affect summary mode (which already shows counts inline)

Example output:
```
rules/:
  ✓ coding-standards.md
  ✓ documentation-guidelines.md
  · experimental-rule.md
  3 items (2 enabled)
```

Closes #137

## Test plan
- [x] Acceptance test: shows count after items in specific category listing
- [x] Acceptance test: shows count after items with `--full` flag
- [x] Acceptance test: does not show duplicate count in summary mode
- [x] Full test suite passes