### PR TITLE
docs: add README files for examples workflow directories

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,7 @@
 # claudeup Examples
 
-Hands-on tutorials for learning claudeup.
+Hands-on tutorials for learning claudeup. Each workflow directory has its own
+README with details on audience, script descriptions, and suggested order.
 
 ## Before You Start
 
@@ -29,7 +30,7 @@ By default, examples run in an isolated temp directory (safe to experiment):
 ./examples/getting-started/01-check-installation.sh
 ```
 
-Temp mode creates a fresh Claude environment - your real settings are not visible or affected.
+Temp mode creates a fresh Claude environment -- your real settings are not visible or affected.
 
 To run against your actual Claude installation:
 
@@ -45,21 +46,51 @@ For scripting or CI (no pauses):
 
 ## Workflows
 
-| Directory | Description |
-|-----------|-------------|
-| `getting-started/` | First steps with claudeup |
-| `profile-management/` | Create and switch configurations |
-| `plugin-management/` | Control your plugins |
-| `troubleshooting/` | Diagnose and fix issues |
-| `team-setup/` | Share configurations across projects |
+Start with **Getting Started**, then explore based on what you need.
+
+| Directory                                    | What it covers                                                  | README                                 |
+| -------------------------------------------- | --------------------------------------------------------------- | -------------------------------------- |
+| [`getting-started/`](getting-started/)       | Verify installation, explore profiles, apply your first profile | [README](getting-started/README.md)    |
+| [`profile-management/`](profile-management/) | Save, create, switch, clone, and compose profiles               | [README](profile-management/README.md) |
+| [`plugin-management/`](plugin-management/)   | List plugins, check for updates, apply upgrades                 | [README](plugin-management/README.md)  |
+| [`team-setup/`](team-setup/)                 | Understand scopes, layer personal and team profiles             | [README](team-setup/README.md)         |
+| [`troubleshooting/`](troubleshooting/)       | Diagnose issues, view event history, diff configuration changes | [README](troubleshooting/README.md)    |
 
 The `lib/` directory contains shared utilities used by all example scripts.
 
+### Suggested learning path
+
+```
+getting-started/  -->  profile-management/  -->  team-setup/
+                            |
+                            v
+                   plugin-management/
+
+         (any time)  troubleshooting/
+```
+
+1. **Getting Started** -- verify claudeup works and learn basic concepts
+2. **Profile Management** -- the core workflow: save, create, switch, compose
+3. **Team Setup** -- layer profiles across scopes for team collaboration
+4. **Plugin Management** -- manage individual plugins and updates
+5. **Troubleshooting** -- use anytime something goes wrong
+
 ## Flags
 
-| Flag | Behavior |
-|------|----------|
-| (none) | Interactive mode with isolated temp directory |
-| `--real` | Operate on actual `~/.claude/` with safety checks |
-| `--non-interactive` | No pauses, for CI/scripting |
-| `--help` | Show usage for the specific example |
+| Flag                | Behavior                                          |
+| ------------------- | ------------------------------------------------- |
+| (none)              | Interactive mode with isolated temp directory     |
+| `--real`            | Operate on actual `~/.claude/` with safety checks |
+| `--non-interactive` | No pauses, for CI/scripting                       |
+| `--help`            | Show usage for the specific example               |
+
+## Temp mode vs real mode
+
+Most examples work in **temp mode** (the default), which creates an isolated
+`~/.claude/` in `/tmp/`. This is safe for experimentation but means some
+commands show placeholder output since there are no real plugins or
+marketplaces to work with.
+
+**Real mode** (`--real`) operates on your actual Claude configuration. It
+requires interactive mode and checks for uncommitted changes in `~/.claude/`
+before proceeding. Use this to see realistic output with your actual plugins.

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -1,0 +1,43 @@
+# Getting Started
+
+First steps with claudeup. Start here if you've just installed claudeup and want
+to verify everything works before diving into profiles and plugins.
+
+## Who is this for?
+
+Anyone who just installed claudeup and wants to:
+
+- Confirm the installation is working
+- Understand what claudeup can see about their Claude Code setup
+- Learn the basic commands before creating or applying profiles
+
+## Scripts
+
+| Script                      | What it does                                                                                                                   |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `01-check-installation.sh`  | Runs `--version`, `status`, and `doctor` to verify claudeup is installed and can see your Claude Code configuration            |
+| `02-explore-profiles.sh`    | Lists available profiles, shows profile contents, and explains Claude Code's three configuration scopes (user, project, local) |
+| `03-apply-first-profile.sh` | Walks through applying a profile -- checks the current state, applies a profile at user scope, and verifies the change         |
+
+## Suggested order
+
+Run them in numbered order. Each script builds on concepts from the previous one:
+
+1. **Check installation** -- make sure claudeup works
+2. **Explore profiles** -- understand what's available
+3. **Apply first profile** -- make your first configuration change
+
+## What you'll learn
+
+- The `status` command gives a high-level overview of plugins, marketplaces, and profiles
+- The `doctor` command diagnoses configuration issues
+- Profiles bundle plugins, MCP servers, and settings into reusable configurations
+- Claude Code has three scopes (user, project, local) with later scopes overriding earlier ones
+- The `--user`, `--project`, and `--local` flags control where a profile is applied
+
+## Next steps
+
+After completing these scripts:
+
+- [Profile Management](../profile-management/) -- create, save, and switch profiles
+- [Plugin Management](../plugin-management/) -- manage individual plugins

--- a/examples/plugin-management/README.md
+++ b/examples/plugin-management/README.md
@@ -1,0 +1,39 @@
+# Plugin Management
+
+View and update the Claude Code plugins managed through claudeup.
+
+## Who is this for?
+
+Users who already have claudeup set up and want to:
+
+- See which plugins are installed and their current state
+- Check for available plugin updates
+- Understand how plugins relate to marketplaces
+
+## Scripts
+
+| Script                 | What it does                                                                                        |
+| ---------------------- | --------------------------------------------------------------------------------------------------- |
+| `01-list-plugins.sh`   | Lists all installed plugins with their enabled/disabled state and shows plugin details via `status` |
+| `03-check-upgrades.sh` | Runs `outdated` to find available updates, then `upgrade` to apply them                             |
+
+> **Note:** Script numbering has a gap (no `02-*`). This is a known issue and does
+> not affect functionality.
+
+## What you'll learn
+
+- `plugin list` shows all plugins and whether they're enabled or disabled
+- `status` groups plugins by their source marketplace
+- `outdated` checks all marketplaces for available updates
+- `upgrade` fetches and applies updates from all marketplaces
+- Plugins are installed from marketplaces (plugin repositories), not individually
+
+## Important details
+
+- The `upgrade` command only runs in `--real` mode since there are no plugins in the temp environment
+- In temp mode, the script shows the commands you would run but skips actual execution
+
+## Next steps
+
+- [Profile Management](../profile-management/) -- bundle plugin selections into reusable profiles
+- [Troubleshooting](../troubleshooting/) -- diagnose plugin issues with `doctor`

--- a/examples/profile-management/README.md
+++ b/examples/profile-management/README.md
@@ -1,0 +1,58 @@
+# Profile Management
+
+Create, save, switch, and compose Claude Code configuration profiles.
+
+Profiles are the core concept in claudeup -- they bundle plugins, MCP servers,
+and settings into named configurations that can be saved, shared, and reapplied.
+
+## Who is this for?
+
+Users who want to:
+
+- Capture their current Claude Code setup so they can restore it later
+- Create purpose-built configurations for different projects or workflows
+- Build composable profile stacks from small, focused building blocks
+- Switch between configurations without manually reconfiguring each time
+
+## Scripts
+
+| Script                     | What it does                                                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `01-save-current-state.sh` | Snapshots your current plugins, MCP servers, and settings into a named profile with `profile save`                                   |
+| `02-create-custom.sh`      | Shows the interactive profile creation wizard (only works in `--real` interactive mode) and the clone-and-modify alternative         |
+| `03-switch-profiles.sh`    | Previews differences with `profile status`, applies a different profile, and verifies the switch                                     |
+| `04-clone-and-modify.sh`   | Clones an existing profile with `profile clone`, then walks through the modify-and-save workflow                                     |
+| `05-composable-stacks.sh`  | Creates building-block profiles in category subdirectories, composes them into stacks via `includes`, and demonstrates nested stacks |
+
+## Suggested order
+
+Start with `01-save-current-state.sh` to understand profiles, then explore based on
+your needs:
+
+- **Quick start:** 01 then 03 (save your setup, learn to switch)
+- **Custom profiles:** 01 then 02 or 04 (save, then create or clone)
+- **Advanced composition:** 01 then 05 (understand stacks and includes)
+
+## What you'll learn
+
+- `profile save <name>` captures your current configuration as a reusable profile
+- `profile create` launches an interactive wizard for building profiles from scratch
+- `profile clone <new> --from <existing>` copies a profile as a starting point
+- `profile apply <name> --user|--project|--local` applies at a specific scope
+- `profile status <name>` previews what would change before applying
+- Profiles can include other profiles via `includes` for composable stacks
+- Building-block profiles live in subdirectories (e.g., `profiles/languages/go.json`)
+- Stack profiles are pure composition -- they only contain name, description, and includes
+
+## Important details
+
+- `02-create-custom.sh` requires both `--real` and interactive mode to run the wizard.
+  In temp mode it shows the commands and workflow as text instead.
+- `05-composable-stacks.sh` creates real profile files in the temp environment to
+  demonstrate stacks. This is the most comprehensive example in the set.
+- Profiles are stored as JSON in `~/.claudeup/profiles/`
+
+## Next steps
+
+- [Team Setup](../team-setup/) -- layer personal and team profiles across scopes
+- [Troubleshooting](../troubleshooting/) -- diagnose profile issues

--- a/examples/team-setup/README.md
+++ b/examples/team-setup/README.md
@@ -1,0 +1,56 @@
+# Team Setup
+
+Share Claude Code configurations across a team using scopes and profile layering.
+
+## Who is this for?
+
+Team leads and developers who want to:
+
+- Establish shared project configurations that every team member gets
+- Layer personal preferences on top of team requirements
+- Understand how Claude Code's scope system enables team collaboration
+
+## Scripts
+
+| Script                   | What it does                                                                                                                                          |
+| ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `01-scoped-profiles.sh`  | Explains the three configuration scopes (user, project, local), their precedence, and how to apply profiles to each scope                             |
+| `04-profile-layering.sh` | Demonstrates combining personal (user scope) and team (project scope) profiles, shows precedence rules, and walks through a recommended team workflow |
+
+> **Note:** Script numbering has gaps (no `02-*` or `03-*`). This is a known issue
+> and does not affect functionality.
+
+## Suggested order
+
+Read `01-scoped-profiles.sh` first to understand scopes, then `04-profile-layering.sh`
+for the practical team workflow.
+
+## What you'll learn
+
+- **User scope** (`~/.claude/settings.json`) holds personal defaults that apply everywhere
+- **Project scope** (`.claude/settings.json`) holds team settings checked into git
+- **Local scope** (`.claude/settings.local.json`) holds personal overrides, git-ignored
+- Later scopes override earlier ones: local > project > user
+- User and project profiles can be active simultaneously -- they combine
+- `profile list` shows which profiles are active at each scope with `*` (active) and `○` (overridden) markers
+
+## Recommended team workflow
+
+The `04-profile-layering.sh` script demonstrates this pattern:
+
+1. **Each developer** saves personal tools as a user-scope profile
+2. **Team lead** creates and applies a project-scope profile, commits `.claude/settings.json`
+3. **After cloning**, each developer runs `claudeup profile apply` to get team config
+4. **Personal overrides** go in local scope (git-ignored)
+
+## Important details
+
+- These scripts are mostly informational -- they explain concepts with example
+  output rather than making changes. They work well in temp mode for learning.
+- `04-profile-layering.sh` shows example JSON and simulated output to illustrate
+  the layering concept without requiring real plugins.
+
+## Next steps
+
+- [Profile Management](../profile-management/) -- create the profiles to use in team setups
+- [Troubleshooting](../troubleshooting/) -- diagnose scope-related issues

--- a/examples/troubleshooting/README.md
+++ b/examples/troubleshooting/README.md
@@ -1,0 +1,61 @@
+# Troubleshooting
+
+Diagnose and fix issues with your Claude Code configuration using claudeup's
+diagnostic and audit tools.
+
+## Who is this for?
+
+Users who need to:
+
+- Figure out why something broke after a configuration change
+- Find and fix corrupted or orphaned plugin entries
+- Trace what claudeup changed and when
+- Understand the before/after state of configuration files
+
+## Scripts
+
+| Script               | What it does                                                                                                            |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `01-run-doctor.sh`   | Runs `doctor` to diagnose issues (missing files, invalid config, path problems) and shows `cleanup` for automatic fixes |
+| `02-view-events.sh`  | Lists recent file operations with `events`, demonstrates filtering by file, operation type, and time range              |
+| `03-diff-changes.sh` | Uses `events diff` to show before/after comparisons of configuration files, with `--full` mode for nested object diffs  |
+
+## Suggested order
+
+Run them in order when troubleshooting:
+
+1. **Run doctor** -- is there a known issue?
+2. **View events** -- what changed recently?
+3. **Diff changes** -- what exactly was different?
+
+## What you'll learn
+
+- `doctor` checks for missing plugin files, invalid configuration, orphaned entries, and path mismatches
+- `cleanup` can automatically fix many issues that `doctor` finds (use `--dry-run` to preview)
+- `events` shows a timestamped log of every file operation claudeup has performed
+- `events --file <path>` filters to changes affecting a specific file
+- `events --since 24h` filters by time window
+- `events diff --file <path>` shows the most recent before/after snapshot for a file
+- `events diff --file <path> --full` recursively diffs nested objects with color-coded symbols (`+` added, `-` removed, `~` modified)
+
+## Debugging workflow
+
+The scripts teach this pattern:
+
+1. Something broke after a change
+2. `claudeup events --since 1h` -- find recent operations
+3. `claudeup events diff --file <path> --full` -- see what changed
+4. Decide: revert with `profile apply` or fix forward
+
+## Important details
+
+- `cleanup` only runs in `--real` mode. In temp mode the script shows the command
+  and `--dry-run` flag.
+- Event logs are stored at `~/.claudeup/events/operations.log`
+- Event logs may contain sensitive data if configuration files include API keys or
+  tokens (see the project CLAUDE.md for privacy details)
+
+## Next steps
+
+- [Getting Started](../getting-started/) -- re-verify installation after fixing issues
+- [Profile Management](../profile-management/) -- restore a known-good profile


### PR DESCRIPTION
## Summary

- Add README.md to each examples subdirectory (getting-started, plugin-management, profile-management, team-setup, troubleshooting) explaining the audience, what each script does, suggested order, and key concepts
- Update `examples/README.md` with links to each subfolder README, a learning path diagram, and a temp vs real mode explanation

## Related

Closes #169 -- workflow improvements and adoption concerns identified during this documentation pass are tracked there.

## Test plan

- [ ] Verify all relative links in READMEs resolve correctly on GitHub
- [ ] Confirm no existing scripts were modified