### PR TITLE
fix: use flat profile format for scope-controlled apply

### DIFF
--- a/examples/team-setup/04-devcontainer-demo.sh
+++ b/examples/team-setup/04-devcontainer-demo.sh
@@ -96,6 +96,7 @@ section "1. Create Fixture Profiles"
 # Profiles use flat format so claudeup-lab controls scope at apply time:
 #   --base-profile → user scope (foundation layer)
 #   --profile      → project scope (layers on top)
+# Compare with demo 02 which uses perScope format for direct claudeup apply.
 step "Create team profile: go-backend-team"
 cat > "$CLAUDEUP_HOME/profiles/go-backend-team.json" <<'PROFILE'
 {


### PR DESCRIPTION
## Summary
- Demo profiles use flat format (no `perScope`) so claudeup-lab controls scope at apply time
- `--base-profile` → user scope, `--profile` → project scope (or user if no base)
- Updated banner and summary text to reflect scope layering

Depends on: https://github.com/claudeup/claudeup-lab/pull/8

## Test plan
- [x] Run devcontainer demo end-to-end with updated claudeup-lab
- [x] Verify profiles apply at correct scopes inside containers