### PR TITLE
docs: convert troubleshooting demos to execute real commands

### DIFF
--- a/examples/troubleshooting/02-view-events.sh
+++ b/examples/troubleshooting/02-view-events.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 # ABOUTME: Example showing how to view file operation history
-# ABOUTME: Demonstrates events and events diff commands
+# ABOUTME: Demonstrates events and events diff commands with real data
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/../lib/common.sh"
 parse_common_args "$@"
 setup_environment
@@ -18,44 +19,71 @@ Essential for understanding "what happened?"
 EOF
 pause
 
-section "1. View Recent Events"
+# ===================================================================
+section "1. Generate Some Events"
+# ===================================================================
+
+step "Create a fixture profile to apply"
+cat > "$CLAUDEUP_HOME/profiles/demo-tools.json" <<'PROFILE'
+{
+  "name": "demo-tools",
+  "description": "Demo profile for event tracking",
+  "plugins": [
+    "superpowers@superpowers-marketplace",
+    "elements-of-style@superpowers-marketplace"
+  ]
+}
+PROFILE
+success "Created demo-tools.json"
+echo
+
+step "Apply the profile to generate events"
+run_cmd "$EXAMPLE_CLAUDEUP_BIN" profile apply demo-tools --user --yes
+pause
+
+# ===================================================================
+section "2. View Recent Events"
+# ===================================================================
 
 step "See the most recent file operations"
 run_cmd "$EXAMPLE_CLAUDEUP_BIN" events --limit 10
+echo
 
 info "Events show:"
-info "  • When changes happened"
-info "  • What files were modified"
-info "  • What operation caused the change"
+info "  - When changes happened"
+info "  - What files were modified"
+info "  - What operation caused the change"
 pause
 
-section "2. Filter Events"
+# ===================================================================
+section "3. Filter Events"
+# ===================================================================
 
-step "Find specific types of changes"
+step "Filter events by file path"
+run_cmd "$EXAMPLE_CLAUDEUP_BIN" events --file "$CLAUDE_CONFIG_DIR/settings.json"
 echo
 
-info "Filter by file:"
-echo -e "${YELLOW}\$ claudeup events --file ~/.claude/settings.json${NC}"
-echo
-
-info "Filter by operation:"
-echo -e "${YELLOW}\$ claudeup events --operation profile${NC}"
-echo
-
-info "Filter by time:"
-echo -e "${YELLOW}\$ claudeup events --since 24h${NC}"
+info "Other filter options:"
+info "  --operation <name>   Filter by operation type"
+info "  --since <duration>   Filter by time (e.g., 24h, 7d)"
+info "  --user / --project / --local   Filter by scope"
 pause
 
-section "3. View Detailed Diffs"
+# ===================================================================
+section "4. View a Diff"
+# ===================================================================
 
-step "See exactly what changed in a file"
-echo -e "${YELLOW}\$ claudeup events diff --file ~/.claude/settings.json${NC}"
+step "See exactly what changed in settings.json"
+run_cmd "$EXAMPLE_CLAUDEUP_BIN" events diff --file "$CLAUDE_CONFIG_DIR/settings.json"
 echo
+
 info "Diffs show before/after snapshots of configuration changes."
 info "Use --full for complete nested object comparison."
 pause
 
+# ===================================================================
 section "Summary"
+# ===================================================================
 
 success "You can track all configuration changes"
 echo


### PR DESCRIPTION
## Summary

- Rewrites `examples/troubleshooting/02-view-events.sh` and `03-diff-changes.sh` from documentation walkthroughs to execute real commands
- Creates fixture profiles and applies them to generate event data
- Runs real `claudeup events` and `claudeup events diff` commands against generated data

Closes #182

## Test plan

- [x] `bash examples/troubleshooting/02-view-events.sh --non-interactive` runs cleanly
- [x] `bash examples/troubleshooting/03-diff-changes.sh --non-interactive` runs cleanly
- [x] `go test ./...` passes