### PR TITLE
fix: validate scope flag in events command

### DIFF
--- a/internal/commands/events.go
+++ b/internal/commands/events.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/claudeup/claudeup/v5/internal/claude"
 	"github.com/claudeup/claudeup/v5/internal/config"
 	"github.com/claudeup/claudeup/v5/internal/events"
 	"github.com/claudeup/claudeup/v5/internal/ui"
@@ -62,6 +63,11 @@ func runEvents(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	eventsScope = resolvedScope
+	if eventsScope != "" {
+		if err := claude.ValidateScope(eventsScope); err != nil {
+			return err
+		}
+	}
 
 	// Get event log path
 	eventsDir := filepath.Join(config.MustClaudeupHome(), "events")


### PR DESCRIPTION
## Summary

- Add `claude.ValidateScope()` call after `resolveScopeFlags` in the events command
- Invalid `--scope` values now return a clear error instead of silently returning no results
- Consistent with all other `resolveScopeFlags` callers (profile list, apply, save, clean, status)

## Test plan

- [ ] `claudeup events --scope banana` returns error instead of empty results
- [ ] `claudeup events --scope project` continues to work normally
- [ ] All existing tests pass