### PR TITLE
docs: update CLAUDE.md for accuracy and completeness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,8 +261,8 @@ This shows:
 - `profile diff` (no args) diffs against the highest-precedence breadcrumb
 - `profile save` (no args) saves to the breadcrumbed profile name
 - `profile delete` and `profile rename` maintain breadcrumb consistency
-- Scope flags (`--user`, `--project`, `--local`) select a specific scope's breadcrumb
-- Breadcrumb errors are non-fatal warnings -- the hint never blocks operations
+- Scope flags (`--user`, `--project`, `--local`, or `--scope <scope>`) select a specific scope's breadcrumb
+- Breadcrumb write errors are non-fatal warnings (apply/delete/rename). If the breadcrumb file is unreadable, no-arg `profile save` and `profile diff` will fail -- recover by passing an explicit profile name.
 
 ## Event Tracking & Privacy
 


### PR DESCRIPTION
## Summary

- Add 8 missing internal packages to Project Structure (backup, breadcrumb, config, events, ext, mcp, pluginsearch, selfupdate, ui)
- Add `last-applied.json` breadcrumb file to Directory Architecture section
- Add Last-Applied Breadcrumb subsection documenting the v5.9.0 feature
- Remove dead reference to `plans/2025-12-17-claude-format-resilience-design.md` (file doesn't exist)

## Test plan

- [x] Documentation-only change, no code modified
- [ ] Review rendered CLAUDE.md for formatting and accuracy