### PR TITLE
fix: surface warnings for missing extensions (#269)

### DIFF
--- a/internal/commands/extension.go
+++ b/internal/commands/extension.go
@@ -492,8 +492,18 @@ func runExtensionsSync(cmd *cobra.Command, args []string) error {
 	manager := ext.NewManager(claudeDir, claudeupHome)
 
 	fmt.Println("Syncing extensions from enabled.json...")
-	if err := manager.Sync(); err != nil {
+	skipped, err := manager.Sync()
+	if err != nil {
 		return fmt.Errorf("sync failed: %w", err)
+	}
+
+	for _, item := range skipped {
+		ui.PrintWarning(fmt.Sprintf("Source not found, skipping: %s", item))
+	}
+
+	if len(skipped) > 0 {
+		ui.PrintWarning(fmt.Sprintf("%d extension(s) skipped due to missing source files: %s",
+			len(skipped), strings.Join(skipped, ", ")))
 	}
 
 	ui.PrintSuccess("Sync complete")

--- a/internal/ext/symlinks.go
+++ b/internal/ext/symlinks.go
@@ -166,9 +166,11 @@ func (m *Manager) Enable(category string, patterns []string) ([]string, []string
 		if err := m.SaveConfig(config); err != nil {
 			return nil, nil, err
 		}
-		if _, err := m.syncCategory(category, config); err != nil {
+		skippedSync, err := m.syncCategory(category, config)
+		if err != nil {
 			return nil, nil, err
 		}
+		notFound = append(notFound, skippedSync...)
 	}
 
 	return enabled, notFound, nil
@@ -224,15 +226,18 @@ func (m *Manager) Disable(category string, patterns []string) ([]string, []strin
 		if err := m.SaveConfig(config); err != nil {
 			return nil, nil, err
 		}
-		if _, err := m.syncCategory(category, config); err != nil {
+		skippedSync, err := m.syncCategory(category, config)
+		if err != nil {
 			return nil, nil, err
 		}
+		notFound = append(notFound, skippedSync...)
 	}
 
 	return disabled, notFound, nil
 }
 
-// syncCategory creates/removes symlinks based on config state
+// syncCategory creates/removes symlinks based on config state.
+// Returns skipped items in "category/item" format where source files were missing.
 func (m *Manager) syncCategory(category string, config Config) ([]string, error) {
 	targetDir := filepath.Join(m.claudeDir, category)
 
@@ -253,6 +258,7 @@ func (m *Manager) syncCategory(category string, config Config) ([]string, error)
 	return m.syncFlatCategory(category, targetDir, catConfig)
 }
 
+// syncFlatCategory syncs non-agent categories. Returns skipped items in "category/item" format.
 func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig map[string]bool) ([]string, error) {
 	// Validate all items before making any changes (fail fast)
 	for item, enabled := range catConfig {
@@ -275,9 +281,12 @@ func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig 
 		}
 
 		source := filepath.Join(m.extDir, category, item)
-		if _, err := os.Stat(source); os.IsNotExist(err) {
-			skipped = append(skipped, category+"/"+item)
-			continue
+		if _, err := os.Stat(source); err != nil {
+			if os.IsNotExist(err) {
+				skipped = append(skipped, category+"/"+item)
+				continue
+			}
+			return skipped, fmt.Errorf("checking source %s: %w", source, err)
 		}
 
 		target := filepath.Join(targetDir, item)
@@ -321,6 +330,7 @@ func (m *Manager) cleanupSymlinksRecursive(dir string) {
 	}
 }
 
+// syncAgents syncs the agents category (supports grouped agents). Returns skipped items in "agents/item" format.
 func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]string, error) {
 	// Validate all items before making any changes (fail fast)
 	for item, enabled := range catConfig {
@@ -374,9 +384,12 @@ func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]str
 			group, agent := parts[0], parts[1]
 
 			source := filepath.Join(m.extDir, "agents", group, agent)
-			if _, err := os.Stat(source); os.IsNotExist(err) {
-				skipped = append(skipped, "agents/"+item)
-				continue
+			if _, err := os.Stat(source); err != nil {
+				if os.IsNotExist(err) {
+					skipped = append(skipped, "agents/"+item)
+					continue
+				}
+				return skipped, fmt.Errorf("checking source %s: %w", source, err)
 			}
 
 			groupTargetDir := filepath.Join(targetDir, group)
@@ -391,9 +404,12 @@ func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]str
 		} else {
 			// Flat agent
 			source := filepath.Join(m.extDir, "agents", item)
-			if _, err := os.Stat(source); os.IsNotExist(err) {
-				skipped = append(skipped, "agents/"+item)
-				continue
+			if _, err := os.Stat(source); err != nil {
+				if os.IsNotExist(err) {
+					skipped = append(skipped, "agents/"+item)
+					continue
+				}
+				return skipped, fmt.Errorf("checking source %s: %w", source, err)
 			}
 
 			target := filepath.Join(targetDir, item)

--- a/internal/ext/symlinks.go
+++ b/internal/ext/symlinks.go
@@ -237,7 +237,7 @@ func (m *Manager) Disable(category string, patterns []string) ([]string, []strin
 }
 
 // syncCategory creates/removes symlinks based on config state.
-// Returns skipped items in "category/item" format where source files were missing.
+// Returns skipped item names (bare, without category prefix) where source files were missing.
 func (m *Manager) syncCategory(category string, config Config) ([]string, error) {
 	targetDir := filepath.Join(m.claudeDir, category)
 
@@ -258,7 +258,7 @@ func (m *Manager) syncCategory(category string, config Config) ([]string, error)
 	return m.syncFlatCategory(category, targetDir, catConfig)
 }
 
-// syncFlatCategory syncs non-agent categories. Returns skipped items in "category/item" format.
+// syncFlatCategory syncs non-agent categories. Returns skipped item names (bare, without category prefix).
 func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig map[string]bool) ([]string, error) {
 	// Validate all items before making any changes (fail fast)
 	for item, enabled := range catConfig {
@@ -283,7 +283,7 @@ func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig 
 		source := filepath.Join(m.extDir, category, item)
 		if _, err := os.Stat(source); err != nil {
 			if os.IsNotExist(err) {
-				skipped = append(skipped, category+"/"+item)
+				skipped = append(skipped, item)
 				continue
 			}
 			return skipped, fmt.Errorf("checking source %s: %w", source, err)
@@ -330,7 +330,7 @@ func (m *Manager) cleanupSymlinksRecursive(dir string) {
 	}
 }
 
-// syncAgents syncs the agents category (supports grouped agents). Returns skipped items in "agents/item" format.
+// syncAgents syncs the agents category (supports grouped agents). Returns skipped item names (bare, without category prefix).
 func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]string, error) {
 	// Validate all items before making any changes (fail fast)
 	for item, enabled := range catConfig {
@@ -386,7 +386,7 @@ func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]str
 			source := filepath.Join(m.extDir, "agents", group, agent)
 			if _, err := os.Stat(source); err != nil {
 				if os.IsNotExist(err) {
-					skipped = append(skipped, "agents/"+item)
+					skipped = append(skipped, item)
 					continue
 				}
 				return skipped, fmt.Errorf("checking source %s: %w", source, err)
@@ -406,7 +406,7 @@ func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]str
 			source := filepath.Join(m.extDir, "agents", item)
 			if _, err := os.Stat(source); err != nil {
 				if os.IsNotExist(err) {
-					skipped = append(skipped, "agents/"+item)
+					skipped = append(skipped, item)
 					continue
 				}
 				return skipped, fmt.Errorf("checking source %s: %w", source, err)
@@ -436,7 +436,9 @@ func (m *Manager) Sync() ([]string, error) {
 		if err != nil {
 			return allSkipped, err
 		}
-		allSkipped = append(allSkipped, skipped...)
+		for _, item := range skipped {
+			allSkipped = append(allSkipped, category+"/"+item)
+		}
 	}
 
 	return allSkipped, nil

--- a/internal/ext/symlinks.go
+++ b/internal/ext/symlinks.go
@@ -166,7 +166,7 @@ func (m *Manager) Enable(category string, patterns []string) ([]string, []string
 		if err := m.SaveConfig(config); err != nil {
 			return nil, nil, err
 		}
-		if err := m.syncCategory(category, config); err != nil {
+		if _, err := m.syncCategory(category, config); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -224,7 +224,7 @@ func (m *Manager) Disable(category string, patterns []string) ([]string, []strin
 		if err := m.SaveConfig(config); err != nil {
 			return nil, nil, err
 		}
-		if err := m.syncCategory(category, config); err != nil {
+		if _, err := m.syncCategory(category, config); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -233,12 +233,12 @@ func (m *Manager) Disable(category string, patterns []string) ([]string, []strin
 }
 
 // syncCategory creates/removes symlinks based on config state
-func (m *Manager) syncCategory(category string, config Config) error {
+func (m *Manager) syncCategory(category string, config Config) ([]string, error) {
 	targetDir := filepath.Join(m.claudeDir, category)
 
 	// Ensure target directory exists
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
-		return err
+		return nil, err
 	}
 
 	catConfig := config[category]
@@ -253,14 +253,14 @@ func (m *Manager) syncCategory(category string, config Config) error {
 	return m.syncFlatCategory(category, targetDir, catConfig)
 }
 
-func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig map[string]bool) error {
+func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig map[string]bool) ([]string, error) {
 	// Validate all items before making any changes (fail fast)
 	for item, enabled := range catConfig {
 		if !enabled {
 			continue
 		}
 		if err := validateItemPath(item); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -268,8 +268,15 @@ func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig 
 	m.cleanupSymlinksRecursive(targetDir)
 
 	// Create symlinks for enabled items
+	var skipped []string
 	for item, enabled := range catConfig {
 		if !enabled {
+			continue
+		}
+
+		source := filepath.Join(m.extDir, category, item)
+		if _, err := os.Stat(source); os.IsNotExist(err) {
+			skipped = append(skipped, category+"/"+item)
 			continue
 		}
 
@@ -279,17 +286,16 @@ func (m *Manager) syncFlatCategory(category string, targetDir string, catConfig 
 		if strings.Contains(item, "/") {
 			parentDir := filepath.Dir(target)
 			if err := os.MkdirAll(parentDir, 0755); err != nil {
-				return err
+				return skipped, err
 			}
 		}
 
-		source := filepath.Join(m.extDir, category, item)
 		if err := createOrVerifySymlink(source, target); err != nil {
-			return err
+			return skipped, err
 		}
 	}
 
-	return nil
+	return skipped, nil
 }
 
 // cleanupSymlinksRecursive removes symlinks in a directory and its subdirectories
@@ -315,14 +321,14 @@ func (m *Manager) cleanupSymlinksRecursive(dir string) {
 	}
 }
 
-func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) error {
+func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) ([]string, error) {
 	// Validate all items before making any changes (fail fast)
 	for item, enabled := range catConfig {
 		if !enabled {
 			continue
 		}
 		if err := validateItemPath(item); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -356,6 +362,7 @@ func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) error 
 	}
 
 	// Create symlinks for enabled agents
+	var skipped []string
 	for item, enabled := range catConfig {
 		if !enabled {
 			continue
@@ -366,43 +373,57 @@ func (m *Manager) syncAgents(targetDir string, catConfig map[string]bool) error 
 			parts := strings.SplitN(item, "/", 2)
 			group, agent := parts[0], parts[1]
 
+			source := filepath.Join(m.extDir, "agents", group, agent)
+			if _, err := os.Stat(source); os.IsNotExist(err) {
+				skipped = append(skipped, "agents/"+item)
+				continue
+			}
+
 			groupTargetDir := filepath.Join(targetDir, group)
 			if err := os.MkdirAll(groupTargetDir, 0755); err != nil {
-				return err
+				return skipped, err
 			}
 
 			target := filepath.Join(groupTargetDir, agent)
-			source := filepath.Join(m.extDir, "agents", group, agent)
 			if err := createOrVerifySymlink(source, target); err != nil {
-				return err
+				return skipped, err
 			}
 		} else {
 			// Flat agent
-			target := filepath.Join(targetDir, item)
 			source := filepath.Join(m.extDir, "agents", item)
+			if _, err := os.Stat(source); os.IsNotExist(err) {
+				skipped = append(skipped, "agents/"+item)
+				continue
+			}
+
+			target := filepath.Join(targetDir, item)
 			if err := createOrVerifySymlink(source, target); err != nil {
-				return err
+				return skipped, err
 			}
 		}
 	}
 
-	return nil
+	return skipped, nil
 }
 
-// Sync synchronizes all categories from config to symlinks
-func (m *Manager) Sync() error {
+// Sync synchronizes all categories from config to symlinks.
+// Returns a list of skipped items (category/item format) where source files were missing.
+func (m *Manager) Sync() ([]string, error) {
 	config, err := m.LoadConfig()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
+	var allSkipped []string
 	for _, category := range AllCategories() {
-		if err := m.syncCategory(category, config); err != nil {
-			return err
+		skipped, err := m.syncCategory(category, config)
+		if err != nil {
+			return allSkipped, err
 		}
+		allSkipped = append(allSkipped, skipped...)
 	}
 
-	return nil
+	return allSkipped, nil
 }
 
 // Import moves items from active directory to extension storage and enables them.

--- a/internal/ext/symlinks_test.go
+++ b/internal/ext/symlinks_test.go
@@ -538,7 +538,7 @@ func TestEnableRejectsPathTraversal(t *testing.T) {
 	manager.SaveConfig(config)
 
 	// Sync should reject path traversal attempts
-	err := manager.Sync()
+	_, err := manager.Sync()
 	if err == nil {
 		t.Fatal("Sync() should have rejected path traversal, got nil error")
 	}
@@ -553,6 +553,48 @@ func TestEnableRejectsPathTraversal(t *testing.T) {
 	legitPath := filepath.Join(claudeDir, "commands", "legit.md")
 	if _, err := os.Lstat(legitPath); err == nil {
 		t.Error("Sync should fail fast - no symlinks created when traversal detected")
+	}
+}
+
+func TestSyncSkipsMissingSourceFiles(t *testing.T) {
+	claudeDir := t.TempDir()
+	claudeupHome := t.TempDir()
+
+	// Create ext directory structure but only one of two source files
+	extDir := filepath.Join(claudeupHome, "ext")
+	os.MkdirAll(filepath.Join(extDir, "rules"), 0755)
+	os.WriteFile(filepath.Join(extDir, "rules", "exists.md"), []byte("# exists"), 0644)
+	// Deliberately NOT creating "missing.md"
+
+	manager := NewManager(claudeDir, claudeupHome)
+	config := Config{
+		"rules": {
+			"exists.md":  true,
+			"missing.md": true,
+		},
+	}
+	manager.SaveConfig(config)
+
+	skipped, err := manager.Sync()
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	// Should report the missing item
+	if len(skipped) != 1 || skipped[0] != "rules/missing.md" {
+		t.Errorf("Sync() skipped = %v, want [rules/missing.md]", skipped)
+	}
+
+	// Existing item should have symlink
+	existsPath := filepath.Join(claudeDir, "rules", "exists.md")
+	if _, err := os.Lstat(existsPath); err != nil {
+		t.Errorf("Expected symlink for exists.md, got error: %v", err)
+	}
+
+	// Missing item should NOT have symlink
+	missingPath := filepath.Join(claudeDir, "rules", "missing.md")
+	if _, err := os.Lstat(missingPath); err == nil {
+		t.Error("Expected no symlink for missing.md, but one exists")
 	}
 }
 

--- a/internal/ext/symlinks_test.go
+++ b/internal/ext/symlinks_test.go
@@ -598,6 +598,64 @@ func TestSyncSkipsMissingSourceFiles(t *testing.T) {
 	}
 }
 
+func TestSyncAgentsSkipsMissingSources(t *testing.T) {
+	claudeDir := t.TempDir()
+	claudeupHome := t.TempDir()
+
+	extDir := filepath.Join(claudeupHome, "ext")
+	// Create one flat agent, skip the other
+	os.MkdirAll(filepath.Join(extDir, "agents"), 0755)
+	os.WriteFile(filepath.Join(extDir, "agents", "exists.md"), []byte("# exists"), 0644)
+	// Deliberately NOT creating "missing.md"
+
+	// Create one grouped agent, skip the other
+	os.MkdirAll(filepath.Join(extDir, "agents", "mygroup"), 0755)
+	os.WriteFile(filepath.Join(extDir, "agents", "mygroup", "present.md"), []byte("# present"), 0644)
+	// Deliberately NOT creating "mygroup/gone.md"
+
+	manager := NewManager(claudeDir, claudeupHome)
+	config := Config{
+		"agents": {
+			"exists.md":          true,
+			"missing.md":         true,
+			"mygroup/present.md": true,
+			"mygroup/gone.md":    true,
+		},
+	}
+	manager.SaveConfig(config)
+
+	skipped, err := manager.Sync()
+	if err != nil {
+		t.Fatalf("Sync() error = %v", err)
+	}
+
+	if len(skipped) != 2 {
+		t.Fatalf("Sync() skipped = %v, want 2 items", skipped)
+	}
+
+	// Verify present items have symlinks
+	existsPath := filepath.Join(claudeDir, "agents", "exists.md")
+	if _, err := os.Lstat(existsPath); err != nil {
+		t.Errorf("Expected symlink for exists.md: %v", err)
+	}
+
+	presentPath := filepath.Join(claudeDir, "agents", "mygroup", "present.md")
+	if _, err := os.Lstat(presentPath); err != nil {
+		t.Errorf("Expected symlink for mygroup/present.md: %v", err)
+	}
+
+	// Verify missing items have no symlinks
+	missingPath := filepath.Join(claudeDir, "agents", "missing.md")
+	if _, err := os.Lstat(missingPath); err == nil {
+		t.Error("Expected no symlink for missing.md")
+	}
+
+	gonePath := filepath.Join(claudeDir, "agents", "mygroup", "gone.md")
+	if _, err := os.Lstat(gonePath); err == nil {
+		t.Error("Expected no symlink for mygroup/gone.md")
+	}
+}
+
 func TestImportAllNoPattern(t *testing.T) {
 	claudeDir := t.TempDir()
 	claudeupHome := t.TempDir()

--- a/internal/ext/uninstall.go
+++ b/internal/ext/uninstall.go
@@ -72,9 +72,11 @@ func (m *Manager) Uninstall(category string, patterns []string) ([]string, []str
 		if err := m.SaveConfig(config); err != nil {
 			return nil, nil, err
 		}
-		if _, err := m.syncCategory(category, config); err != nil {
+		skippedSync, err := m.syncCategory(category, config)
+		if err != nil {
 			return nil, nil, err
 		}
+		notFound = append(notFound, skippedSync...)
 	}
 
 	return removed, notFound, nil

--- a/internal/ext/uninstall.go
+++ b/internal/ext/uninstall.go
@@ -72,7 +72,7 @@ func (m *Manager) Uninstall(category string, patterns []string) ([]string, []str
 		if err := m.SaveConfig(config); err != nil {
 			return nil, nil, err
 		}
-		if err := m.syncCategory(category, config); err != nil {
+		if _, err := m.syncCategory(category, config); err != nil {
 			return nil, nil, err
 		}
 	}

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -18,6 +18,7 @@ import (
 	"github.com/claudeup/claudeup/v5/internal/config"
 	"github.com/claudeup/claudeup/v5/internal/ext"
 	"github.com/claudeup/claudeup/v5/internal/secrets"
+	"github.com/claudeup/claudeup/v5/internal/ui"
 )
 
 // ApplyOptions controls how a profile is applied
@@ -1244,8 +1245,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		installMCPServersCLI(scopeProfile.MCPServers, "", secretChain, executor, result)
 
 		if profile.PerScope.User.Extensions != nil {
-			if err := applyExtensionsScoped(profile, profile.PerScope.User.Extensions, ScopeUser, claudeDir, claudeupHome, projectDir); err != nil {
+			if notFound, err := applyExtensionsScoped(profile, profile.PerScope.User.Extensions, ScopeUser, claudeDir, claudeupHome, projectDir); err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("user-scope extensions: %w", err))
+			} else {
+				warnNotFoundExtensions(notFound)
 			}
 		}
 	}
@@ -1271,8 +1274,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		installPluginsForScope(scopeProfile.Plugins, "project", opts.Reinstall, executor, result)
 
 		if profile.PerScope.Project.Extensions != nil {
-			if err := applyExtensionsScoped(profile, profile.PerScope.Project.Extensions, ScopeProject, claudeDir, claudeupHome, projectDir); err != nil {
+			if notFound, err := applyExtensionsScoped(profile, profile.PerScope.Project.Extensions, ScopeProject, claudeDir, claudeupHome, projectDir); err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("project-scope extensions: %w", err))
+			} else {
+				warnNotFoundExtensions(notFound)
 			}
 		}
 	}
@@ -1288,8 +1293,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		installMCPServersCLI(scopeProfile.MCPServers, "local", secretChain, executor, result)
 
 		if profile.PerScope.Local.Extensions != nil {
-			if err := applyExtensionsScoped(profile, profile.PerScope.Local.Extensions, ScopeLocal, claudeDir, claudeupHome, projectDir); err != nil {
+			if notFound, err := applyExtensionsScoped(profile, profile.PerScope.Local.Extensions, ScopeLocal, claudeDir, claudeupHome, projectDir); err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("local-scope extensions: %w", err))
+			} else {
+				warnNotFoundExtensions(notFound)
 			}
 		}
 	}
@@ -1408,15 +1415,21 @@ func applyExtensions(profile *Profile, claudeDir, claudeupHome string) error {
 	if profile.Extensions == nil {
 		return nil
 	}
-	return applyExtensionsScoped(profile, profile.Extensions, ScopeUser, claudeDir, claudeupHome, "")
+	notFound, err := applyExtensionsScoped(profile, profile.Extensions, ScopeUser, claudeDir, claudeupHome, "")
+	if err != nil {
+		return err
+	}
+	warnNotFoundExtensions(notFound)
+	return nil
 }
 
 // applyExtensionsScoped enables extensions at the specified scope.
-// User scope: creates symlinks from claudeDir to claudeupHome/ext (existing behavior).
+// User scope: creates symlinks from claudeDir to claudeupHome/ext.
 // Project/local scope: copies files from claudeupHome/ext into projectDir/.claude/.
-func applyExtensionsScoped(_ *Profile, items *ExtensionSettings, scope Scope, claudeDir, claudeupHome, projectDir string) error {
+// Returns a list of not-found items in "category/item" format.
+func applyExtensionsScoped(_ *Profile, items *ExtensionSettings, scope Scope, claudeDir, claudeupHome, projectDir string) ([]string, error) {
 	if items == nil {
-		return nil
+		return nil, nil
 	}
 
 	if scope == ScopeProject || scope == ScopeLocal {
@@ -1426,8 +1439,20 @@ func applyExtensionsScoped(_ *Profile, items *ExtensionSettings, scope Scope, cl
 	return applyExtensionsSymlink(items, claudeDir, claudeupHome)
 }
 
+// warnNotFoundExtensions emits per-item and summary warnings for missing extensions.
+func warnNotFoundExtensions(notFound []string) {
+	for _, item := range notFound {
+		ui.PrintWarning(fmt.Sprintf("Extension %q not found, skipping", item))
+	}
+	if len(notFound) > 0 {
+		ui.PrintWarning(fmt.Sprintf("%d extension(s) from profile not found and skipped: %s",
+			len(notFound), strings.Join(notFound, ", ")))
+	}
+}
+
 // applyExtensionsSymlink enables extensions via symlinks (user scope).
-func applyExtensionsSymlink(items *ExtensionSettings, claudeDir, claudeupHome string) error {
+// Returns a list of not-found items in "category/item" format.
+func applyExtensionsSymlink(items *ExtensionSettings, claudeDir, claudeupHome string) ([]string, error) {
 	manager := ext.NewManager(claudeDir, claudeupHome)
 
 	type categoryItems struct {
@@ -1444,20 +1469,25 @@ func applyExtensionsSymlink(items *ExtensionSettings, claudeDir, claudeupHome st
 		{ext.CategoryOutputStyles, items.OutputStyles},
 	}
 
+	var allNotFound []string
 	for _, ci := range categories {
 		if len(ci.patterns) > 0 {
-			if _, _, err := manager.Enable(ci.category, ci.patterns); err != nil {
-				return fmt.Errorf("failed to enable %s: %w", ci.category, err)
+			_, notFound, err := manager.Enable(ci.category, ci.patterns)
+			if err != nil {
+				return allNotFound, fmt.Errorf("failed to enable %s: %w", ci.category, err)
+			}
+			for _, item := range notFound {
+				allNotFound = append(allNotFound, ci.category+"/"+item)
 			}
 		}
 	}
 
-	return nil
+	return allNotFound, nil
 }
 
 // applyExtensionsCopy copies extensions into the project's .claude/ directory.
-// Only categories that Claude Code reads from project scope are allowed.
-func applyExtensionsCopy(items *ExtensionSettings, claudeupHome, projectDir string) error {
+// Returns a list of not-found items in "category/item" format.
+func applyExtensionsCopy(items *ExtensionSettings, claudeupHome, projectDir string) ([]string, error) {
 	localDir := filepath.Join(claudeupHome, "ext")
 
 	type categoryItems struct {
@@ -1474,21 +1504,26 @@ func applyExtensionsCopy(items *ExtensionSettings, claudeupHome, projectDir stri
 		{ext.CategoryOutputStyles, items.OutputStyles},
 	}
 
+	var allNotFound []string
 	for _, ci := range categories {
 		if len(ci.patterns) == 0 {
 			continue
 		}
 
 		if err := ext.ValidateProjectScope(ci.category); err != nil {
-			return fmt.Errorf("cannot copy %s to project scope: %w", ci.category, err)
+			return allNotFound, fmt.Errorf("cannot copy %s to project scope: %w", ci.category, err)
 		}
 
-		if _, _, err := ext.CopyToProject(localDir, ci.category, ci.patterns, projectDir); err != nil {
-			return fmt.Errorf("failed to copy %s to project: %w", ci.category, err)
+		_, notFound, err := ext.CopyToProject(localDir, ci.category, ci.patterns, projectDir)
+		if err != nil {
+			return allNotFound, fmt.Errorf("failed to copy %s to project: %w", ci.category, err)
+		}
+		for _, item := range notFound {
+			allNotFound = append(allNotFound, ci.category+"/"+item)
 		}
 	}
 
-	return nil
+	return allNotFound, nil
 }
 
 // applySettingsHooks merges profile hooks into settings.json

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -1245,10 +1245,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		installMCPServersCLI(scopeProfile.MCPServers, "", secretChain, executor, result)
 
 		if profile.PerScope.User.Extensions != nil {
-			if notFound, err := applyExtensionsScoped(profile, profile.PerScope.User.Extensions, ScopeUser, claudeDir, claudeupHome, projectDir); err != nil {
+			notFound, err := applyExtensionsScoped(profile, profile.PerScope.User.Extensions, ScopeUser, claudeDir, claudeupHome, projectDir)
+			warnNotFoundExtensions(notFound)
+			if err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("user-scope extensions: %w", err))
-			} else {
-				warnNotFoundExtensions(notFound)
 			}
 		}
 	}
@@ -1274,10 +1274,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		installPluginsForScope(scopeProfile.Plugins, "project", opts.Reinstall, executor, result)
 
 		if profile.PerScope.Project.Extensions != nil {
-			if notFound, err := applyExtensionsScoped(profile, profile.PerScope.Project.Extensions, ScopeProject, claudeDir, claudeupHome, projectDir); err != nil {
+			notFound, err := applyExtensionsScoped(profile, profile.PerScope.Project.Extensions, ScopeProject, claudeDir, claudeupHome, projectDir)
+			warnNotFoundExtensions(notFound)
+			if err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("project-scope extensions: %w", err))
-			} else {
-				warnNotFoundExtensions(notFound)
 			}
 		}
 	}
@@ -1293,10 +1293,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		installMCPServersCLI(scopeProfile.MCPServers, "local", secretChain, executor, result)
 
 		if profile.PerScope.Local.Extensions != nil {
-			if notFound, err := applyExtensionsScoped(profile, profile.PerScope.Local.Extensions, ScopeLocal, claudeDir, claudeupHome, projectDir); err != nil {
+			notFound, err := applyExtensionsScoped(profile, profile.PerScope.Local.Extensions, ScopeLocal, claudeDir, claudeupHome, projectDir)
+			warnNotFoundExtensions(notFound)
+			if err != nil {
 				result.Errors = append(result.Errors, fmt.Errorf("local-scope extensions: %w", err))
-			} else {
-				warnNotFoundExtensions(notFound)
 			}
 		}
 	}
@@ -1426,7 +1426,7 @@ func applyExtensions(profile *Profile, claudeDir, claudeupHome string) error {
 // applyExtensionsScoped enables extensions at the specified scope.
 // User scope: creates symlinks from claudeDir to claudeupHome/ext.
 // Project/local scope: copies files from claudeupHome/ext into projectDir/.claude/.
-// Returns a list of not-found items in "category/item" format.
+// Returns a list of unmatched patterns in "category/pattern" format.
 func applyExtensionsScoped(_ *Profile, items *ExtensionSettings, scope Scope, claudeDir, claudeupHome, projectDir string) ([]string, error) {
 	if items == nil {
 		return nil, nil
@@ -1451,7 +1451,7 @@ func warnNotFoundExtensions(notFound []string) {
 }
 
 // applyExtensionsSymlink enables extensions via symlinks (user scope).
-// Returns a list of not-found items in "category/item" format.
+// Returns a list of unmatched patterns in "category/pattern" format.
 func applyExtensionsSymlink(items *ExtensionSettings, claudeDir, claudeupHome string) ([]string, error) {
 	manager := ext.NewManager(claudeDir, claudeupHome)
 
@@ -1486,7 +1486,8 @@ func applyExtensionsSymlink(items *ExtensionSettings, claudeDir, claudeupHome st
 }
 
 // applyExtensionsCopy copies extensions into the project's .claude/ directory.
-// Returns a list of not-found items in "category/item" format.
+// Only categories permitted at project/local scope are allowed; others return an error.
+// Returns a list of not-found patterns in "category/pattern" format.
 func applyExtensionsCopy(items *ExtensionSettings, claudeupHome, projectDir string) ([]string, error) {
 	localDir := filepath.Join(claudeupHome, "ext")
 

--- a/internal/profile/apply_scoped_local_items_test.go
+++ b/internal/profile/apply_scoped_local_items_test.go
@@ -350,8 +350,8 @@ func TestApplyExtensionsScopedReportsNotFound(t *testing.T) {
 		t.Fatalf("applyExtensionsScoped() error = %v", err)
 	}
 
-	if len(notFound) != 1 {
-		t.Errorf("applyExtensionsScoped() notFound = %v, want 1 item", notFound)
+	if len(notFound) != 1 || notFound[0] != "rules/missing.md" {
+		t.Errorf("applyExtensionsScoped() notFound = %v, want [rules/missing.md]", notFound)
 	}
 }
 

--- a/internal/profile/apply_scoped_local_items_test.go
+++ b/internal/profile/apply_scoped_local_items_test.go
@@ -38,7 +38,7 @@ func TestApplyExtensionsProjectScopeCopiesFiles(t *testing.T) {
 	}
 
 	// Apply at project scope
-	err := applyExtensionsScoped(profile, extensions, ScopeProject, claudeDir, claudeupHome, projectDir)
+	_, err := applyExtensionsScoped(profile, extensions, ScopeProject, claudeDir, claudeupHome, projectDir)
 	if err != nil {
 		t.Fatalf("applyExtensionsScoped failed: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestApplyExtensionsProjectScopeRejectsUnsupportedCategories(t *testing.T) {
 	}
 
 	// Apply at project scope should fail for unsupported category
-	err := applyExtensionsScoped(profile, extensions, ScopeProject, claudeDir, claudeupHome, projectDir)
+	_, err := applyExtensionsScoped(profile, extensions, ScopeProject, claudeDir, claudeupHome, projectDir)
 	if err == nil {
 		t.Fatal("expected error for unsupported category at project scope")
 	}
@@ -114,7 +114,7 @@ func TestApplyExtensionsUserScopeUsesSymlinks(t *testing.T) {
 	}
 
 	// Apply at user scope should use symlinks (existing behavior)
-	err := applyExtensionsScoped(profile, extensions, ScopeUser, claudeDir, claudeupHome, "")
+	_, err := applyExtensionsScoped(profile, extensions, ScopeUser, claudeDir, claudeupHome, "")
 	if err != nil {
 		t.Fatalf("applyExtensionsScoped failed: %v", err)
 	}
@@ -266,6 +266,116 @@ func TestApplyAllScopesWithScopedExtensions(t *testing.T) {
 	projectAgentPath := filepath.Join(projectDir, ".claude", "agents", "reviewer.md")
 	if _, err := os.Stat(projectAgentPath); errors.Is(err, fs.ErrNotExist) {
 		t.Error("expected reviewer.md copied to project .claude/agents/")
+	}
+}
+
+func TestApplyExtensionsSymlinkReportsNotFound(t *testing.T) {
+	claudeDir := t.TempDir()
+	claudeupHome := t.TempDir()
+
+	// Create ext dir with only one of two items
+	extDir := filepath.Join(claudeupHome, "ext")
+	mustMkdir(t, filepath.Join(extDir, "rules"))
+	mustWriteFile(t, filepath.Join(extDir, "rules", "exists.md"), "# exists")
+	mustWriteFile(t, filepath.Join(claudeupHome, "enabled.json"), "{}")
+
+	items := &ExtensionSettings{
+		Rules: []string{"exists.md", "missing.md"},
+	}
+
+	notFound, err := applyExtensionsSymlink(items, claudeDir, claudeupHome)
+	if err != nil {
+		t.Fatalf("applyExtensionsSymlink() error = %v", err)
+	}
+
+	if len(notFound) != 1 || notFound[0] != "rules/missing.md" {
+		t.Errorf("applyExtensionsSymlink() notFound = %v, want [rules/missing.md]", notFound)
+	}
+
+	// Verify the existing one was still enabled
+	existsPath := filepath.Join(claudeDir, "rules", "exists.md")
+	if _, err := os.Lstat(existsPath); err != nil {
+		t.Errorf("Expected symlink for exists.md: %v", err)
+	}
+}
+
+func TestApplyExtensionsCopyReportsNotFound(t *testing.T) {
+	claudeupHome := t.TempDir()
+	projectDir := t.TempDir()
+
+	// Create ext dir with only one of two items
+	extDir := filepath.Join(claudeupHome, "ext")
+	mustMkdir(t, filepath.Join(extDir, "rules"))
+	mustWriteFile(t, filepath.Join(extDir, "rules", "exists.md"), "# exists")
+
+	// Create project .claude dir
+	mustMkdir(t, filepath.Join(projectDir, ".claude"))
+
+	items := &ExtensionSettings{
+		Rules: []string{"exists.md", "missing.md"},
+	}
+
+	notFound, err := applyExtensionsCopy(items, claudeupHome, projectDir)
+	if err != nil {
+		t.Fatalf("applyExtensionsCopy() error = %v", err)
+	}
+
+	if len(notFound) != 1 || notFound[0] != "rules/missing.md" {
+		t.Errorf("applyExtensionsCopy() notFound = %v, want [rules/missing.md]", notFound)
+	}
+
+	// Verify the existing one was still copied
+	existsPath := filepath.Join(projectDir, ".claude", "rules", "exists.md")
+	if _, err := os.Stat(existsPath); err != nil {
+		t.Errorf("Expected copied file for exists.md: %v", err)
+	}
+}
+
+func TestApplyExtensionsScopedReportsNotFound(t *testing.T) {
+	claudeDir := t.TempDir()
+	claudeupHome := t.TempDir()
+
+	// Create ext dir with only one of two items
+	extDir := filepath.Join(claudeupHome, "ext")
+	mustMkdir(t, filepath.Join(extDir, "rules"))
+	mustWriteFile(t, filepath.Join(extDir, "rules", "exists.md"), "# exists")
+	mustWriteFile(t, filepath.Join(claudeupHome, "enabled.json"), "{}")
+
+	items := &ExtensionSettings{
+		Rules: []string{"exists.md", "missing.md"},
+	}
+
+	notFound, err := applyExtensionsScoped(nil, items, ScopeUser, claudeDir, claudeupHome, "")
+	if err != nil {
+		t.Fatalf("applyExtensionsScoped() error = %v", err)
+	}
+
+	if len(notFound) != 1 {
+		t.Errorf("applyExtensionsScoped() notFound = %v, want 1 item", notFound)
+	}
+}
+
+func TestApplyExtensionsScopedNoWarningsWhenAllPresent(t *testing.T) {
+	claudeDir := t.TempDir()
+	claudeupHome := t.TempDir()
+
+	extDir := filepath.Join(claudeupHome, "ext")
+	mustMkdir(t, filepath.Join(extDir, "rules"))
+	mustWriteFile(t, filepath.Join(extDir, "rules", "one.md"), "# one")
+	mustWriteFile(t, filepath.Join(extDir, "rules", "two.md"), "# two")
+	mustWriteFile(t, filepath.Join(claudeupHome, "enabled.json"), "{}")
+
+	items := &ExtensionSettings{
+		Rules: []string{"one.md", "two.md"},
+	}
+
+	notFound, err := applyExtensionsScoped(nil, items, ScopeUser, claudeDir, claudeupHome, "")
+	if err != nil {
+		t.Fatalf("applyExtensionsScoped() error = %v", err)
+	}
+
+	if len(notFound) != 0 {
+		t.Errorf("applyExtensionsScoped() notFound = %v, want empty", notFound)
 	}
 }
 

--- a/test/integration/ext/extension_suite_test.go
+++ b/test/integration/ext/extension_suite_test.go
@@ -87,7 +87,7 @@ func TestExtensionIntegration(t *testing.T) {
 	}
 
 	// Test: Sync
-	err = manager.Sync()
+	_, err = manager.Sync()
 	if err != nil {
 		t.Fatalf("Sync() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- `profile apply` now warns (per-item + summary) when extensions referenced in a profile are not found in extension storage, instead of silently skipping them
- `ext sync` validates source files exist before creating symlinks -- missing sources are skipped and reported
- `syncAgents` gets the same source-existence check for both flat and grouped agents
- Follow-up issue #270 created for `--strict` flag (fail on missing extensions for CI use)

## Test Plan

- [x] `go test ./... -count=1` -- all pass
- [x] `go vet ./...` -- clean
- [ ] `TestSyncSkipsMissingSourceFiles` -- verifies flat category skipping
- [ ] `TestSyncAgentsSkipsMissingSources` -- verifies agent category skipping (flat + grouped)
- [ ] `TestApplyExtensionsSymlinkReportsNotFound` -- verifies symlink path notFound
- [ ] `TestApplyExtensionsCopyReportsNotFound` -- verifies copy path notFound
- [ ] `TestApplyExtensionsScopedReportsNotFound` -- verifies scoped dispatch
- [ ] `TestApplyExtensionsScopedNoWarningsWhenAllPresent` -- verifies happy path

Closes #269