### PR TITLE
fix: qualify plugin names with marketplace ref in interactive wizard (#272)

### DIFF
--- a/internal/commands/profile_cmd.go
+++ b/internal/commands/profile_cmd.go
@@ -2711,7 +2711,15 @@ func runProfileCreate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("failed to select plugins from %s: %w", marketplace.DisplayName(), err)
 		}
 
-		allPlugins = append(allPlugins, plugins...)
+		// Qualify each plugin with the marketplace repo name (not owner/repo).
+		// The Claude CLI expects "plugin@repo-name" format.
+		ref := marketplace.Repo
+		if idx := strings.LastIndex(ref, "/"); idx != -1 {
+			ref = ref[idx+1:]
+		}
+		for _, p := range plugins {
+			allPlugins = append(allPlugins, p+"@"+ref)
+		}
 	}
 
 	// Step 4: Generate and edit description


### PR DESCRIPTION
## Summary

- Interactive `profile create` wizard passes bare plugin names (e.g., `pyright-lsp`) to `CreateFromFlags` which requires `name@marketplace-ref` format
- One-line fix: qualify each plugin with `@marketplace.Repo` in the wizard loop

## Test Plan

- [x] `go test ./... -count=1` -- all pass
- [ ] Manual: `claudeup profile create test` -- select marketplace, select plugins, verify no format error

Closes #272