### PR TITLE
fix: handle MCP already-exists gracefully during profile apply

### DIFF
--- a/internal/commands/setup.go
+++ b/internal/commands/setup.go
@@ -564,6 +564,9 @@ func showApplyResults(result *profile.ApplyResult) {
 	if len(result.MCPServersInstalled) > 0 {
 		fmt.Printf("  %s Installed %d MCP servers\n", ui.Success(ui.SymbolSuccess), len(result.MCPServersInstalled))
 	}
+	if len(result.MCPServersAlreadyPresent) > 0 {
+		fmt.Printf("  %s %d MCP servers were already configured\n", ui.Muted(ui.SymbolSuccess), len(result.MCPServersAlreadyPresent))
+	}
 	if len(result.MarketplacesAdded) > 0 {
 		fmt.Printf("  %s Added %d marketplaces\n", ui.Success(ui.SymbolSuccess), len(result.MarketplacesAdded))
 	}

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -981,10 +981,13 @@ func installMCPServersCLI(servers []MCPServer, scope string, secretChain *secret
 
 		args := buildMCPAddArgs(mcp, resolved)
 		output, err := executor.RunWithOutput(args...)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("MCP %s: %w\n  Output: %s", mcp.Name, err, strings.TrimSpace(output)))
-		} else {
+		switch mcpErr := checkMCPAlreadyExists(output, err); {
+		case mcpErr == nil:
 			result.MCPServersInstalled = append(result.MCPServersInstalled, mcp.Name)
+		case errors.Is(mcpErr, errMCPAlreadyExists):
+			result.MCPServersAlreadyPresent = append(result.MCPServersAlreadyPresent, mcp.Name)
+		default:
+			result.Errors = append(result.Errors, fmt.Errorf("MCP %s: %w", mcp.Name, mcpErr))
 		}
 	}
 }

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -1268,6 +1268,16 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 			return nil, fmt.Errorf("failed to apply user scope: %w", err)
 		}
 
+		// When replacing user scope, remove existing MCP servers before re-adding
+		if opts.ReplaceUserScope && len(scopeProfile.MCPServers) > 0 {
+			existing, readErr := ReadMCPServersForScope(claudeJSONPath, "", "user")
+			if readErr == nil {
+				for _, srv := range existing {
+					executor.RunWithOutput("mcp", "remove", srv.Name)
+				}
+			}
+		}
+
 		installPluginsForScope(scopeProfile.Plugins, "", opts.Reinstall, executor, result)
 		installMCPServersCLI(scopeProfile.MCPServers, "", secretChain, executor, result)
 

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -283,12 +283,13 @@ func ApplyWithOptions(profile *Profile, claudeDir, claudeJSONPath, claudeupHome 
 // convertConcurrentResult converts ConcurrentApplyResult to ApplyResult
 func convertConcurrentResult(cr *ConcurrentApplyResult) *ApplyResult {
 	return &ApplyResult{
-		PluginsInstalled:      cr.PluginsInstalled,
-		PluginsAlreadyPresent: cr.PluginsSkipped,
-		MCPServersInstalled:   cr.MCPServersInstalled,
-		MarketplacesAdded:     cr.MarketplacesInstalled,
-		Warnings:              cr.Warnings,
-		Errors:                cr.Errors,
+		PluginsInstalled:         cr.PluginsInstalled,
+		PluginsAlreadyPresent:    cr.PluginsSkipped,
+		MCPServersInstalled:      cr.MCPServersInstalled,
+		MCPServersAlreadyPresent: cr.MCPServersSkipped,
+		MarketplacesAdded:        cr.MarketplacesInstalled,
+		Warnings:                 cr.Warnings,
+		Errors:                   cr.Errors,
 	}
 }
 
@@ -1273,7 +1274,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 			existing, readErr := ReadMCPServersForScope(claudeJSONPath, "", "user")
 			if readErr == nil {
 				for _, srv := range existing {
-					executor.RunWithOutput("mcp", "remove", srv.Name)
+					if _, removeErr := executor.RunWithOutput("mcp", "remove", srv.Name); removeErr != nil {
+						result.Warnings = append(result.Warnings,
+							fmt.Errorf("could not remove MCP server %s before replace: %w", srv.Name, removeErr))
+					}
 				}
 			}
 		}

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -692,10 +692,13 @@ func applyUserScope(profile *Profile, claudeDir, claudeJSONPath, claudeupHome st
 	for _, mcp := range diff.MCPToInstall {
 		args := buildMCPAddArgs(mcp, resolvedMCP[mcp.Name])
 		output, err := executor.RunWithOutput(args...)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("failed to add MCP server %s: %w\n  Output: %s", mcp.Name, err, strings.TrimSpace(output)))
-		} else {
+		switch mcpErr := checkMCPAlreadyExists(output, err); {
+		case mcpErr == nil:
 			result.MCPServersInstalled = append(result.MCPServersInstalled, mcp.Name)
+		case errors.Is(mcpErr, errMCPAlreadyExists):
+			result.MCPServersAlreadyPresent = append(result.MCPServersAlreadyPresent, mcp.Name)
+		default:
+			result.Errors = append(result.Errors, fmt.Errorf("failed to add MCP server %s: %w", mcp.Name, mcpErr))
 		}
 	}
 

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -54,16 +54,17 @@ func (e *DefaultExecutor) RunWithOutput(args ...string) (string, error) {
 
 // ApplyResult contains the results of applying a profile
 type ApplyResult struct {
-	PluginsRemoved        []string
-	PluginsInstalled      []string
-	PluginsAlreadyRemoved []string // Plugins that were already uninstalled
-	PluginsAlreadyPresent []string // Plugins that were already installed
-	MCPServersRemoved     []string
-	MCPServersInstalled   []string
-	MarketplacesAdded     []string
-	MarketplacesRemoved   []string
-	Warnings              []error // Non-fatal pre-operation notices (e.g. load failures with fallback)
-	Errors                []error // Actual install/operation failures
+	PluginsRemoved           []string
+	PluginsInstalled         []string
+	PluginsAlreadyRemoved    []string // Plugins that were already uninstalled
+	PluginsAlreadyPresent    []string // Plugins that were already installed
+	MCPServersRemoved        []string
+	MCPServersInstalled      []string
+	MCPServersAlreadyPresent []string // MCP servers that were already configured
+	MarketplacesAdded        []string
+	MarketplacesRemoved      []string
+	Warnings                 []error // Non-fatal pre-operation notices (e.g. load failures with fallback)
+	Errors                   []error // Actual install/operation failures
 }
 
 // Diff represents what needs to change to apply a profile
@@ -916,6 +917,23 @@ func installPluginsForScope(plugins []string, scope string, reinstall bool, exec
 	result.PluginsInstalled = append(result.PluginsInstalled, installResult.Installed...)
 	result.PluginsAlreadyPresent = append(result.PluginsAlreadyPresent, installResult.Skipped...)
 	result.Errors = append(result.Errors, installResult.Errors...)
+}
+
+// errMCPAlreadyExists is returned when `claude mcp add` reports a server
+// is already configured at the target scope.
+var errMCPAlreadyExists = errors.New("MCP server already exists")
+
+// checkMCPAlreadyExists inspects the output and error from a `claude mcp add`
+// command. Returns nil if the command succeeded, errMCPAlreadyExists if the
+// server was already configured, or the original error with output context.
+func checkMCPAlreadyExists(output string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if strings.Contains(output, "already exists") {
+		return errMCPAlreadyExists
+	}
+	return fmt.Errorf("%w\n  Output: %s", err, strings.TrimSpace(output))
 }
 
 // installMCPServersCLI installs MCP servers via CLI and aggregates results.

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -456,10 +456,13 @@ func applyLocalScope(profile *Profile, claudeDir, claudeJSONPath, claudeupHome s
 		mcpCopy.Scope = "local" // Override to local
 		args := buildMCPAddArgs(mcpCopy, resolvedMCP[mcp.Name])
 		output, err := executor.RunWithOutput(args...)
-		if err != nil {
-			result.Errors = append(result.Errors, fmt.Errorf("MCP %s: %w\n  Output: %s", mcp.Name, err, strings.TrimSpace(output)))
-		} else {
+		switch mcpErr := checkMCPAlreadyExists(output, err); {
+		case mcpErr == nil:
 			result.MCPServersInstalled = append(result.MCPServersInstalled, mcp.Name)
+		case errors.Is(mcpErr, errMCPAlreadyExists):
+			result.MCPServersAlreadyPresent = append(result.MCPServersAlreadyPresent, mcp.Name)
+		default:
+			result.Errors = append(result.Errors, fmt.Errorf("MCP %s: %w", mcp.Name, mcpErr))
 		}
 	}
 

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -1269,8 +1269,9 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 			return nil, fmt.Errorf("failed to apply user scope: %w", err)
 		}
 
-		// When replacing user scope, remove existing MCP servers before re-adding
-		if opts.ReplaceUserScope && len(scopeProfile.MCPServers) > 0 {
+		// When replacing user scope, remove existing MCP servers so reality
+		// matches the profile. An empty MCP list means "no MCP servers wanted."
+		if opts.ReplaceUserScope {
 			existing, readErr := ReadMCPServersForScope(claudeJSONPath, "", "user")
 			if readErr != nil {
 				result.Warnings = append(result.Warnings,

--- a/internal/profile/apply.go
+++ b/internal/profile/apply.go
@@ -1272,7 +1272,10 @@ func ApplyAllScopes(profile *Profile, claudeDir, claudeJSONPath, projectDir, cla
 		// When replacing user scope, remove existing MCP servers before re-adding
 		if opts.ReplaceUserScope && len(scopeProfile.MCPServers) > 0 {
 			existing, readErr := ReadMCPServersForScope(claudeJSONPath, "", "user")
-			if readErr == nil {
+			if readErr != nil {
+				result.Warnings = append(result.Warnings,
+					fmt.Errorf("could not read existing MCP servers for replace: %w", readErr))
+			} else {
 				for _, srv := range existing {
 					if _, removeErr := executor.RunWithOutput("mcp", "remove", srv.Name); removeErr != nil {
 						result.Warnings = append(result.Warnings,

--- a/internal/profile/apply_allscopes_test.go
+++ b/internal/profile/apply_allscopes_test.go
@@ -969,6 +969,79 @@ func TestApplyAllScopesMCPAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestApplyAllScopesReplaceRemovesMCPServers(t *testing.T) {
+	env := setupAllScopesTestEnv(t)
+
+	// Write existing MCP servers to .claude.json
+	claudeJSON := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"old-server": map[string]interface{}{
+				"command": "npx",
+				"args":    []string{"old-pkg"},
+			},
+		},
+	}
+	writeTestJSON(t, env.claudeJSONPath, claudeJSON)
+
+	executor := &allScopesMockExecutor{}
+
+	p := &Profile{
+		Name: "test-replace-mcp",
+		PerScope: &PerScopeSettings{
+			User: &ScopeSettings{
+				MCPServers: []MCPServer{
+					{Name: "new-server", Command: "npx", Args: []string{"new-pkg"}},
+				},
+			},
+		},
+	}
+
+	result, err := ApplyAllScopes(p, env.claudeDir, env.claudeJSONPath, env.projectDir, env.claudeupHome, nil, &ApplyAllScopesOptions{
+		Executor:         executor,
+		Output:           io.Discard,
+		ReplaceUserScope: true,
+	})
+	if err != nil {
+		t.Fatalf("ApplyAllScopes failed: %v", err)
+	}
+
+	// Should have issued mcp remove for old-server
+	if !executor.hasCommand("mcp", "remove", "old-server") {
+		t.Errorf("Expected 'mcp remove old-server' command, got commands: %v", executor.commands)
+	}
+
+	// Should have issued mcp add for new-server
+	if !executor.hasCommand("mcp", "add", "new-server") {
+		t.Errorf("Expected 'mcp add new-server' command, got commands: %v", executor.commands)
+	}
+
+	// mcp remove should come before mcp add
+	removeIdx := -1
+	addIdx := -1
+	for i, cmd := range executor.commands {
+		cmdStr := strings.Join(cmd, " ")
+		if strings.HasPrefix(cmdStr, "mcp remove old-server") && removeIdx == -1 {
+			removeIdx = i
+		}
+		if strings.HasPrefix(cmdStr, "mcp add new-server") && addIdx == -1 {
+			addIdx = i
+		}
+	}
+	if removeIdx == -1 {
+		t.Fatal("mcp remove command not found")
+	}
+	if addIdx == -1 {
+		t.Fatal("mcp add command not found")
+	}
+	if removeIdx >= addIdx {
+		t.Errorf("Expected mcp remove (%d) before mcp add (%d)", removeIdx, addIdx)
+	}
+
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got: %v", result.Errors)
+	}
+}
+
 func TestApplyAllScopesInstallMarketplacesOutput(t *testing.T) {
 	env := setupAllScopesTestEnv(t)
 	var buf strings.Builder

--- a/internal/profile/apply_allscopes_test.go
+++ b/internal/profile/apply_allscopes_test.go
@@ -1042,6 +1042,51 @@ func TestApplyAllScopesReplaceRemovesMCPServers(t *testing.T) {
 	}
 }
 
+func TestApplyAllScopesReplaceClearsMCPWithEmptyProfile(t *testing.T) {
+	env := setupAllScopesTestEnv(t)
+
+	// Write existing MCP servers to .claude.json
+	claudeJSON := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"old-server": map[string]interface{}{
+				"command": "npx",
+				"args":    []string{"old-pkg"},
+			},
+		},
+	}
+	writeTestJSON(t, env.claudeJSONPath, claudeJSON)
+
+	executor := &allScopesMockExecutor{}
+
+	// Profile with user scope but NO MCP servers
+	p := &Profile{
+		Name: "test-replace-empty-mcp",
+		PerScope: &PerScopeSettings{
+			User: &ScopeSettings{
+				Plugins: []string{},
+			},
+		},
+	}
+
+	result, err := ApplyAllScopes(p, env.claudeDir, env.claudeJSONPath, env.projectDir, env.claudeupHome, nil, &ApplyAllScopesOptions{
+		Executor:         executor,
+		Output:           io.Discard,
+		ReplaceUserScope: true,
+	})
+	if err != nil {
+		t.Fatalf("ApplyAllScopes failed: %v", err)
+	}
+
+	// Should still remove old-server even though profile has no MCP servers
+	if !executor.hasCommand("mcp", "remove", "old-server") {
+		t.Errorf("Expected 'mcp remove old-server' command, got commands: %v", executor.commands)
+	}
+
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got: %v", result.Errors)
+	}
+}
+
 func TestApplyAllScopesInstallMarketplacesOutput(t *testing.T) {
 	env := setupAllScopesTestEnv(t)
 	var buf strings.Builder

--- a/internal/profile/apply_allscopes_test.go
+++ b/internal/profile/apply_allscopes_test.go
@@ -5,6 +5,7 @@ package profile
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -925,6 +926,46 @@ func TestApplyAllScopesMarketplaceErrorIncludesOutput(t *testing.T) {
 	errMsg := result.Errors[0].Error()
 	if !strings.Contains(errMsg, "network timeout") {
 		t.Errorf("expected error to include CLI output, got: %s", errMsg)
+	}
+}
+
+func TestApplyAllScopesMCPAlreadyExists(t *testing.T) {
+	env := setupAllScopesTestEnv(t)
+	executor := &allScopesMockExecutor{
+		failOnWithOutput: map[string]string{
+			"mcp add context7": "MCP server context7 already exists in user config",
+		},
+	}
+
+	p := &Profile{
+		Name: "test-mcp-exists",
+		PerScope: &PerScopeSettings{
+			User: &ScopeSettings{
+				MCPServers: []MCPServer{
+					{Name: "context7", Command: "npx", Args: []string{"-y", "@context7/mcp"}},
+				},
+			},
+		},
+	}
+
+	result, err := ApplyAllScopes(p, env.claudeDir, env.claudeJSONPath, env.projectDir, env.claudeupHome, nil, &ApplyAllScopesOptions{
+		Executor: executor,
+		Output:   io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("ApplyAllScopes failed: %v", err)
+	}
+
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got: %v", result.Errors)
+	}
+
+	if len(result.MCPServersAlreadyPresent) != 1 || result.MCPServersAlreadyPresent[0] != "context7" {
+		t.Errorf("Expected context7 in MCPServersAlreadyPresent, got: %v", result.MCPServersAlreadyPresent)
+	}
+
+	if len(result.MCPServersInstalled) > 0 {
+		t.Errorf("Expected no MCPServersInstalled, got: %v", result.MCPServersInstalled)
 	}
 }
 

--- a/internal/profile/apply_concurrent.go
+++ b/internal/profile/apply_concurrent.go
@@ -27,8 +27,9 @@ type ConcurrentApplyResult struct {
 	PluginsInstalled      []string
 	PluginsSkipped        []string
 	MCPServersInstalled   []string
-	Warnings              []error // Non-fatal pre-operation notices (e.g. load failures with fallback)
-	Errors                []error // Actual install/operation failures
+	MCPServersSkipped     []string // MCP servers skipped (already configured)
+	Warnings              []error  // Non-fatal pre-operation notices (e.g. load failures with fallback)
+	Errors                []error  // Actual install/operation failures
 }
 
 // ApplyConcurrently installs marketplaces and plugins concurrently with progress tracking

--- a/internal/profile/apply_concurrent.go
+++ b/internal/profile/apply_concurrent.go
@@ -3,6 +3,7 @@
 package profile
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -161,8 +162,8 @@ func ApplyConcurrently(profile *Profile, opts ConcurrentApplyOptions) (*Concurre
 					mcpCopy.Scope = opts.Scope
 				}
 				args := buildMCPAddArgs(mcpCopy, nil)
-				_, err := opts.Executor.RunWithOutput(args...)
-				return err
+				output, err := opts.Executor.RunWithOutput(args...)
+				return checkMCPAlreadyExists(output, err)
 			},
 		}
 	}
@@ -198,6 +199,8 @@ func ApplyConcurrently(profile *Profile, opts ConcurrentApplyOptions) (*Concurre
 			} else if jr.Type == "mcp" {
 				if jr.Success {
 					result.MCPServersInstalled = append(result.MCPServersInstalled, jr.Name)
+				} else if errors.Is(jr.Error, errMCPAlreadyExists) {
+					result.MCPServersSkipped = append(result.MCPServersSkipped, jr.Name)
 				} else {
 					result.Errors = append(result.Errors, fmt.Errorf("mcp %s: %w", jr.Name, jr.Error))
 				}

--- a/internal/profile/apply_concurrent_test.go
+++ b/internal/profile/apply_concurrent_test.go
@@ -4,6 +4,8 @@ package profile
 
 import (
 	"bytes"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -221,5 +223,69 @@ func TestApplyConcurrentlyWithLoadError(t *testing.T) {
 	// No actual install errors should exist (mock executor succeeds)
 	if len(result.Errors) != 0 {
 		t.Errorf("expected 0 errors, got %d: %v", len(result.Errors), result.Errors)
+	}
+}
+
+// failingMockExecutor returns a specified output and error for matching commands
+type failingMockExecutor struct {
+	mu               sync.Mutex
+	failOnWithOutput map[string]string // command prefix -> output to return alongside an error
+}
+
+func (m *failingMockExecutor) Run(args ...string) error {
+	_, err := m.RunWithOutput(args...)
+	return err
+}
+
+func (m *failingMockExecutor) RunWithOutput(args ...string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := strings.Join(args, " ")
+	for prefix, output := range m.failOnWithOutput {
+		if strings.HasPrefix(key, prefix) {
+			return output, errors.New("exit status 1")
+		}
+	}
+	return "", nil
+}
+
+func TestApplyConcurrentlyMCPAlreadyExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	pluginsDir := filepath.Join(claudeDir, "plugins")
+	os.MkdirAll(pluginsDir, 0755)
+
+	writeTestJSON(t, filepath.Join(pluginsDir, "installed_plugins.json"), map[string]interface{}{"version": 2, "plugins": map[string]interface{}{}})
+	writeTestJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]interface{}{"enabledPlugins": map[string]bool{}})
+	writeTestJSON(t, filepath.Join(pluginsDir, "known_marketplaces.json"), map[string]interface{}{})
+
+	executor := &failingMockExecutor{
+		failOnWithOutput: map[string]string{
+			"mcp add context7": "MCP server context7 already exists in user config",
+		},
+	}
+
+	p := &Profile{
+		Name: "test-concurrent-mcp",
+		MCPServers: []MCPServer{
+			{Name: "context7", Command: "npx", Args: []string{"-y", "@context7/mcp"}},
+		},
+	}
+
+	result, err := ApplyConcurrently(p, ConcurrentApplyOptions{
+		ClaudeDir: claudeDir,
+		Scope:     "user",
+		Output:    io.Discard,
+		Executor:  executor,
+	})
+	if err != nil {
+		t.Fatalf("ApplyConcurrently failed: %v", err)
+	}
+
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got: %v", result.Errors)
+	}
+	if len(result.MCPServersSkipped) != 1 || result.MCPServersSkipped[0] != "context7" {
+		t.Errorf("Expected context7 in MCPServersSkipped, got: %v", result.MCPServersSkipped)
 	}
 }

--- a/internal/profile/apply_test.go
+++ b/internal/profile/apply_test.go
@@ -2126,3 +2126,40 @@ func TestApplyUserScopeMCPAlreadyExists(t *testing.T) {
 		t.Errorf("Expected context7 in MCPServersAlreadyPresent, got: %v", result.MCPServersAlreadyPresent)
 	}
 }
+
+func TestApplyLocalScopeMCPAlreadyExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	pluginsDir := filepath.Join(claudeDir, "plugins")
+	os.MkdirAll(pluginsDir, 0755)
+
+	writeTestJSON(t, filepath.Join(pluginsDir, "installed_plugins.json"), map[string]interface{}{"version": 2, "plugins": map[string]interface{}{}})
+	writeTestJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]interface{}{"enabledPlugins": map[string]bool{}})
+	writeTestJSON(t, filepath.Join(pluginsDir, "known_marketplaces.json"), map[string]interface{}{})
+	writeTestJSON(t, filepath.Join(tmpDir, ".claude.json"), map[string]interface{}{})
+
+	profile := &Profile{
+		Name: "test-local-mcp",
+		MCPServers: []MCPServer{
+			{Name: "local-server", Command: "npx", Args: []string{"server-pkg"}, Scope: "local"},
+		},
+	}
+
+	executor := &mockExecutorWithOutput{
+		outputs: map[string]string{
+			"mcp add local-server -s local -- npx server-pkg": "MCP server local-server already exists in local config",
+		},
+	}
+
+	result, err := applyLocalScope(profile, claudeDir, filepath.Join(tmpDir, ".claude.json"), claudeDir, nil, ApplyOptions{ProjectDir: tmpDir}, executor)
+	if err != nil {
+		t.Fatalf("applyLocalScope failed: %v", err)
+	}
+
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got: %v", result.Errors)
+	}
+	if len(result.MCPServersAlreadyPresent) != 1 || result.MCPServersAlreadyPresent[0] != "local-server" {
+		t.Errorf("Expected local-server in MCPServersAlreadyPresent, got: %v", result.MCPServersAlreadyPresent)
+	}
+}

--- a/internal/profile/apply_test.go
+++ b/internal/profile/apply_test.go
@@ -2054,3 +2054,38 @@ func TestFilterValidMarketplaceKeys(t *testing.T) {
 		})
 	}
 }
+
+func TestCheckMCPAlreadyExists(t *testing.T) {
+	t.Run("nil error returns nil", func(t *testing.T) {
+		err := checkMCPAlreadyExists("some output", nil)
+		if err != nil {
+			t.Errorf("expected nil, got %v", err)
+		}
+	})
+
+	t.Run("already exists returns sentinel", func(t *testing.T) {
+		err := checkMCPAlreadyExists(
+			"MCP server context7 already exists in user config",
+			fmt.Errorf("exit status 1"),
+		)
+		if !errors.Is(err, errMCPAlreadyExists) {
+			t.Errorf("expected errMCPAlreadyExists, got %v", err)
+		}
+	})
+
+	t.Run("other error passes through with output", func(t *testing.T) {
+		err := checkMCPAlreadyExists(
+			"connection refused",
+			fmt.Errorf("exit status 1"),
+		)
+		if errors.Is(err, errMCPAlreadyExists) {
+			t.Error("should not be errMCPAlreadyExists")
+		}
+		if err == nil {
+			t.Error("expected non-nil error")
+		}
+		if !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("expected output in error, got %v", err)
+		}
+	})
+}

--- a/internal/profile/apply_test.go
+++ b/internal/profile/apply_test.go
@@ -1341,7 +1341,7 @@ func (m *mockExecutorWithOutput) RunWithOutput(args ...string) (string, error) {
 		key := strings.Join(args, " ")
 		if output, ok := m.outputs[key]; ok {
 			// If output contains error keywords, return error
-			if strings.Contains(output, "not found") || strings.Contains(output, "Failed") {
+			if strings.Contains(output, "not found") || strings.Contains(output, "Failed") || strings.Contains(output, "already exists") {
 				return output, fmt.Errorf("exit status 1")
 			}
 		}
@@ -2088,4 +2088,41 @@ func TestCheckMCPAlreadyExists(t *testing.T) {
 			t.Errorf("expected output in error, got %v", err)
 		}
 	})
+}
+
+func TestApplyUserScopeMCPAlreadyExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	pluginsDir := filepath.Join(claudeDir, "plugins")
+	os.MkdirAll(pluginsDir, 0755)
+
+	writeTestJSON(t, filepath.Join(pluginsDir, "installed_plugins.json"), map[string]interface{}{"version": 2, "plugins": map[string]interface{}{}})
+	writeTestJSON(t, filepath.Join(claudeDir, "settings.json"), map[string]interface{}{"enabledPlugins": map[string]bool{}})
+	writeTestJSON(t, filepath.Join(pluginsDir, "known_marketplaces.json"), map[string]interface{}{})
+	writeTestJSON(t, filepath.Join(tmpDir, ".claude.json"), map[string]interface{}{})
+
+	profile := &Profile{
+		Name: "test-mcp-exists",
+		MCPServers: []MCPServer{
+			{Name: "context7", Command: "npx", Args: []string{"-y", "@context7/mcp"}, Scope: "user"},
+		},
+	}
+
+	executor := &mockExecutorWithOutput{
+		outputs: map[string]string{
+			"mcp add context7 -s user -- npx -y @context7/mcp": "MCP server context7 already exists in user config",
+		},
+	}
+
+	result, err := applyUserScope(profile, claudeDir, filepath.Join(tmpDir, ".claude.json"), claudeDir, nil, ApplyOptions{}, executor)
+	if err != nil {
+		t.Fatalf("applyUserScope failed: %v", err)
+	}
+
+	if len(result.Errors) > 0 {
+		t.Errorf("Expected no errors, got: %v", result.Errors)
+	}
+	if len(result.MCPServersAlreadyPresent) != 1 || result.MCPServersAlreadyPresent[0] != "context7" {
+		t.Errorf("Expected context7 in MCPServersAlreadyPresent, got: %v", result.MCPServersAlreadyPresent)
+	}
 }


### PR DESCRIPTION
## Summary

- Add `checkMCPAlreadyExists` helper to detect "already exists" output from `claude mcp add` and treat it as a skip instead of a fatal error
- Fix all 4 MCP install paths: `installMCPServersCLI`, user-scope diff apply, local-scope apply, and concurrent apply
- Make `--replace` flag clear existing MCP servers before re-adding them in `ApplyAllScopes`
- Display "already configured" count in apply results output

## Test plan

- [x] Unit tests for `checkMCPAlreadyExists` helper (nil, sentinel, pass-through)
- [x] `ApplyAllScopes` with MCP "already exists" output -- no errors, tracked as already present
- [x] User-scope diff apply with MCP "already exists" -- graceful handling
- [x] Local-scope apply with MCP "already exists" -- graceful handling
- [x] Concurrent apply with MCP "already exists" -- routed to skipped list
- [x] `--replace` with existing MCP servers -- removes before re-adding, correct ordering
- [x] Full test suite passes (unit, integration, acceptance)
- [ ] Manual smoke test: `cu profile save current-user-settings && cu profile apply current-user-settings -y --replace`