### PR TITLE
refactor(wizard): extract shared number-parsing helper for fallback menus

### DIFF
--- a/internal/profile/wizard.go
+++ b/internal/profile/wizard.go
@@ -353,8 +353,7 @@ func fallbackMarketplaceSelection(wio WizardIO, available []Marketplace) ([]Mark
 		return nil, fmt.Errorf("failed to read input: %w", err)
 	}
 
-	input = strings.TrimSpace(input)
-	if input == "" {
+	if strings.TrimSpace(input) == "" {
 		return nil, fmt.Errorf("no marketplaces selected")
 	}
 

--- a/internal/profile/wizard.go
+++ b/internal/profile/wizard.go
@@ -311,6 +311,34 @@ func SelectMarketplaces(wio WizardIO, available []Marketplace) ([]Marketplace, e
 	return selected, nil
 }
 
+// parseNumberedSelection parses a comma-separated string of 1-based menu numbers,
+// validates each is in range [1, max], deduplicates, and returns 0-based indices.
+func parseNumberedSelection(input string, max int) ([]int, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return nil, fmt.Errorf("no selection")
+	}
+
+	parts := strings.Split(input, ",")
+	indices := make([]int, 0, len(parts))
+	seen := make(map[int]bool)
+
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		num, err := strconv.Atoi(part)
+		if err != nil || num < 1 || num > max {
+			return nil, fmt.Errorf("invalid selection: %s", part)
+		}
+		if seen[num] {
+			continue
+		}
+		seen[num] = true
+		indices = append(indices, num-1)
+	}
+
+	return indices, nil
+}
+
 // fallbackMarketplaceSelection provides simple numbered menu when gum unavailable
 func fallbackMarketplaceSelection(wio WizardIO, available []Marketplace) ([]Marketplace, error) {
 	fmt.Fprintln(wio.Out, "\nSelect marketplaces (enter numbers separated by commas):")
@@ -325,28 +353,19 @@ func fallbackMarketplaceSelection(wio WizardIO, available []Marketplace) ([]Mark
 		return nil, fmt.Errorf("failed to read input: %w", err)
 	}
 
-	// Parse comma-separated numbers
 	input = strings.TrimSpace(input)
 	if input == "" {
 		return nil, fmt.Errorf("no marketplaces selected")
 	}
 
-	parts := strings.Split(input, ",")
-	selected := make([]Marketplace, 0)
-	seen := make(map[int]bool)
+	indices, err := parseNumberedSelection(input, len(available))
+	if err != nil {
+		return nil, err
+	}
 
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		idx, err := strconv.Atoi(part)
-		if err != nil || idx < 1 || idx > len(available) {
-			return nil, fmt.Errorf("invalid selection: %s", part)
-		}
-		// Skip duplicates
-		if seen[idx] {
-			continue
-		}
-		seen[idx] = true
-		selected = append(selected, available[idx-1])
+	selected := make([]Marketplace, 0, len(indices))
+	for _, idx := range indices {
+		selected = append(selected, available[idx])
 	}
 
 	return selected, nil
@@ -461,22 +480,14 @@ func fallbackCategorySelection(wio WizardIO, categories []Category) ([]Category,
 		return []Category{}, nil
 	}
 
-	parts := strings.Split(input, ",")
-	selected := make([]Category, 0)
-	seen := make(map[int]bool)
+	indices, err := parseNumberedSelection(input, len(categories))
+	if err != nil {
+		return nil, err
+	}
 
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		idx, err := strconv.Atoi(part)
-		if err != nil || idx < 1 || idx > len(categories) {
-			return nil, fmt.Errorf("invalid selection: %s", part)
-		}
-		// Skip duplicates
-		if seen[idx] {
-			continue
-		}
-		seen[idx] = true
-		selected = append(selected, categories[idx-1])
+	selected := make([]Category, 0, len(indices))
+	for _, idx := range indices {
+		selected = append(selected, categories[idx])
 	}
 
 	return selected, nil
@@ -605,23 +616,14 @@ func fallbackPluginRefinement(wio WizardIO, availablePlugins []string, installed
 		return result, nil
 	}
 
-	// Parse comma-separated numbers
-	parts := strings.Split(input, ",")
-	selected := make([]string, 0)
-	seen := make(map[int]bool)
+	indices, err := parseNumberedSelection(input, len(availablePlugins))
+	if err != nil {
+		return nil, err
+	}
 
-	for _, part := range parts {
-		part = strings.TrimSpace(part)
-		idx, err := strconv.Atoi(part)
-		if err != nil || idx < 1 || idx > len(availablePlugins) {
-			return nil, fmt.Errorf("invalid selection: %s", part)
-		}
-		// Skip duplicates
-		if seen[idx] {
-			continue
-		}
-		seen[idx] = true
-		selected = append(selected, availablePlugins[idx-1])
+	selected := make([]string, 0, len(indices))
+	for _, idx := range indices {
+		selected = append(selected, availablePlugins[idx])
 	}
 
 	return selected, nil

--- a/internal/profile/wizard_test.go
+++ b/internal/profile/wizard_test.go
@@ -155,6 +155,9 @@ func TestParseNumberedSelection(t *testing.T) {
 		{"empty invalid", "", 3, nil, "no selection"},
 		{"negative invalid", "-1", 3, nil, "invalid selection: -1"},
 		{"mixed valid and invalid", "1,abc", 3, nil, "invalid selection: abc"},
+		{"trailing comma", "1,2,", 3, nil, "invalid selection: "},
+		{"whitespace only", "   ", 3, nil, "no selection"},
+		{"max zero rejects all", "1", 0, nil, "invalid selection: 1"},
 	}
 
 	for _, tt := range tests {

--- a/internal/profile/wizard_test.go
+++ b/internal/profile/wizard_test.go
@@ -137,6 +137,53 @@ func TestIsGumCancel(t *testing.T) {
 	})
 }
 
+func TestParseNumberedSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		max     int
+		want    []int
+		wantErr string
+	}{
+		{"single valid", "2", 3, []int{1}, ""},
+		{"multiple valid", "1,3", 3, []int{0, 2}, ""},
+		{"with spaces", " 1 , 2 ", 3, []int{0, 1}, ""},
+		{"deduplicates", "1,1,2", 3, []int{0, 1}, ""},
+		{"zero invalid", "0", 3, nil, "invalid selection: 0"},
+		{"over max invalid", "4", 3, nil, "invalid selection: 4"},
+		{"non-numeric invalid", "abc", 3, nil, "invalid selection: abc"},
+		{"empty invalid", "", 3, nil, "no selection"},
+		{"negative invalid", "-1", 3, nil, "invalid selection: -1"},
+		{"mixed valid and invalid", "1,abc", 3, nil, "invalid selection: abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseNumberedSelection(tt.input, tt.max)
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error = %q, want containing %q", err.Error(), tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %v (len %d), want %v (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("got[%d] = %d, want %d", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestRefinePluginSelection_GumCrash(t *testing.T) {
 	t.Run("returns error on gum crash", func(t *testing.T) {
 		wio, errBuf := testGumWizardIO(func(args ...string) ([]byte, error) {


### PR DESCRIPTION
## Summary

- Extracts `parseNumberedSelection(input string, max int) ([]int, error)` helper that parses comma-separated 1-based menu numbers, validates range, and deduplicates
- Replaces duplicated inline parsing in `fallbackMarketplaceSelection`, `fallbackCategorySelection`, and `fallbackPluginRefinement`
- Adds 10 unit tests covering valid inputs, boundary conditions, and error cases

## Test plan

- [x] All 10 `TestParseNumberedSelection` cases pass (valid, dedup, boundary, error)
- [x] Existing integration tests for `SelectMarketplaces` fallback path pass (numbered selection, comma-separated, dedup, out-of-range, non-numeric)
- [x] Existing integration tests for `SelectPluginsForMarketplace` category path pass (category selection, skip with 'q', EOF)
- [x] Existing unit tests for `refinePluginSelection` gum crash handling pass
- [x] Full `go test ./...` passes with zero failures
- [x] `go vet` clean

Closes #281